### PR TITLE
Add generic helper function to compare desired and actual states in brownfield resources

### DIFF
--- a/docs/design-decisions/brownfield-diff-reconciliation.md
+++ b/docs/design-decisions/brownfield-diff-reconciliation.md
@@ -1,0 +1,57 @@
+# Design Decision Document: Brownfield KRM Spec Comparison & Reconciliation Pipeline for Direct Controllers
+
+## 1. Problem Statement
+
+In Config Connector (KCC) direct controllers, **Brownfield resources** need to support the legacy "unmanage" behavior for backward compatibility. This means the comparison of the desired and the actual state for a brownfield direct controller needs to "skip" unmanaged fields. The reconciler must compare `desiredKRM` against live `actualProto` to only detect legitimate drift on user-managed fields.
+
+Currently (as of July 31 2026), most of the state comparisons for brownfield resources are hand-written. We should provide a generic solution to avoid the manual work.
+
+One thing to note is that the list field is always managed by KCC once it is set in the desired state. We currently don't distinguish between list elements that are managed by KCC and those that are not. We also don't support unmanaged nested fields in the list element. More details can be found at https://docs.cloud.google.com/config-connector/docs/concepts/managing-fields-externally#behavior_for_list_fields_in_resource_spec.
+
+## 2. Proposed Solution: The 5-Step Pipeline (6 States)
+
+We introduce a single generic function, `common.CompareBrownfieldSpec`, in `pkg/controller/direct/common/compare.go`. It processes `desired` and `actual` through 5 transformation steps across 6 states:
+
+```
+A.  actualProto (GCP API Response)
+       │
+       ▼  1. actualKRM = Spec_FromProto(actualProto)
+B.  actualKRM (Strips status, output-only, & unsupported fields)
+       │
+       ▼  2. MergeUnsetFields(desiredKRM, actualKRM)
+C.  desiredKRM (Adopts actualKRM's values for unspecified fields)
+       │
+       │  3. desiredProtoMasked = Spec_ToProto(desiredKRM)
+       ▼     actualProtoMasked  = Spec_ToProto(actualKRM)
+D.  [desiredProtoMasked, actualProtoMasked]
+       │
+       ▼  4. Normalize & SortRepeatedFields on both Protos
+E.  [Normalized & Deterministically Sorted Protos]
+       │
+       ▼  5. DiffForTopLevelFields(desiredProtoMasked, actualProtoMasked)
+F.  (structuredreporting.Diff, fieldmaskpb.FieldMask)
+```
+
+## 3. Detailed Step Breakdown
+
+### Step 1: `actualProto` -> `actualKRM` (`Spec_FromProto`)
+- Converts raw GCP Proto to KRM Spec struct using each resource's own mapper `Spec_FromProto`.
+- **Key Benefit**: Inherently masks out all status fields, `etag`s, output-only fields, and unsupported GCP API fields.
+
+### Step 2: Merge Unspecified Fields (`MergeUnsetFields`)
+- Recursively traverses `desiredKRM` and `actualKRM` using Go reflection.
+- For any pointer/slice field where `desiredKRM` is `nil` (unspecified by the user), it copies the value from `actualKRM`.
+- **Key Benefit**: Adopts existing values from actual into `desiredKRM` for both top-level and nested fields.
+
+### Step 3: Convert KRM Specs to Protos (`Spec_ToProto`)
+- Converts both `desiredKRM` and `actualKRM` to Proto messages (`desiredProtoMasked` and `actualProtoMasked`).
+- **Key Benefit**: Ensures both Proto messages share identical schema boundaries and mapper normalization.
+
+### Step 4: Normalization & Slice Sorting (`normalize` & `SortRepeatedFields`)
+- Applies controller-specific link/reference normalizations if provided (e.g. converting GCP project numbers to project IDs in parent links). Normalization is required for resources with reference or link fields to ensure consistent formatting between desired and actual.
+- Traverses repeated fields (slices) in both Proto messages to normalize order for unordered lists.
+- **Key Benefit**: Eliminates false diffs caused by reference format mismatches or GCP list reordering.
+
+### Step 5: Top-Level Diff & FieldMask Generation (`DiffForTopLevelFields`)
+- Compares top-level fields between `desiredProtoMasked` and `actualProtoMasked`.
+- **Key Benefit**: Emits structured diffs for logging and returns top-level field paths for `fieldmaskpb.FieldMask`, which is required by GCP Update RPCs.

--- a/pkg/controller/direct/common/compare.go
+++ b/pkg/controller/direct/common/compare.go
@@ -16,13 +16,17 @@ package common
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"reflect"
 	"slices"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/structuredreporting"
 	"google.golang.org/genproto/googleapis/api/annotations"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -286,4 +290,159 @@ func valToAny(v protoreflect.Value) any {
 		return nil
 	}
 	return v.Interface()
+}
+
+// MergeUnsetFields recursively copies non-nil values from actual into desired for any pointer/slice fields where desired is nil.
+func MergeUnsetFields(desired, actual reflect.Value) {
+	if !desired.IsValid() || !actual.IsValid() {
+		return
+	}
+
+	switch desired.Kind() {
+	case reflect.Ptr:
+		if desired.IsNil() && !actual.IsNil() {
+			desired.Set(actual)
+		} else if !desired.IsNil() && !actual.IsNil() {
+			MergeUnsetFields(desired.Elem(), actual.Elem())
+		}
+
+	case reflect.Struct:
+		for i := 0; i < desired.NumField(); i++ {
+			field := desired.Type().Field(i)
+			if field.IsExported() {
+				MergeUnsetFields(desired.Field(i), actual.Field(i))
+			}
+		}
+
+	case reflect.Slice, reflect.Map:
+		if desired.IsNil() && !actual.IsNil() {
+			desired.Set(actual)
+		}
+	}
+}
+
+var deterministicJSON = protojson.MarshalOptions{}
+
+// SortRepeatedFields recursively traverses populated list fields in a proto message and sorts them deterministically.
+func SortRepeatedFields(msg protoreflect.Message) {
+	if msg == nil || !msg.IsValid() {
+		return
+	}
+	msg.Range(func(fd protoreflect.FieldDescriptor, val protoreflect.Value) bool {
+		if fd.IsList() {
+			sortProtoReflectList(val.List())
+		} else if fd.IsMap() {
+			val.Map().Range(func(k protoreflect.MapKey, v protoreflect.Value) bool {
+				if msg, ok := v.Interface().(protoreflect.Message); ok {
+					SortRepeatedFields(msg)
+				}
+				return true
+			})
+		} else if fd.Kind() == protoreflect.MessageKind {
+			SortRepeatedFields(val.Message())
+		}
+		return true
+	})
+}
+
+func sortProtoReflectList(list protoreflect.List) {
+	n := list.Len()
+	if n <= 1 {
+		return
+	}
+
+	type itemKey struct {
+		val protoreflect.Value
+		key string
+	}
+
+	items := make([]itemKey, n)
+	for i := 0; i < n; i++ {
+		val := list.Get(i)
+		var key string
+		if msgVal, ok := val.Interface().(protoreflect.Message); ok {
+			SortRepeatedFields(msgVal)
+			if pb, ok := msgVal.Interface().(proto.Message); ok {
+				bytes, err := deterministicJSON.Marshal(pb)
+				if err == nil {
+					key = string(bytes)
+				}
+			}
+			if key == "" {
+				key = fmt.Sprintf("%+v", msgVal.Interface())
+			}
+		} else {
+			key = fmt.Sprintf("%+v", val.Interface())
+		}
+		items[i] = itemKey{val: val, key: key}
+	}
+
+	slices.SortFunc(items, func(a, b itemKey) int {
+		return strings.Compare(a.key, b.key)
+	})
+
+	for i := 0; i < n; i++ {
+		list.Set(i, items[i].val)
+	}
+}
+
+// CompareBrownfieldSpec executes the 5-step brownfield spec comparison pipeline.
+func CompareBrownfieldSpec[SpecType any, ProtoT interface {
+	proto.Message
+}](
+	ctx context.Context,
+	desiredKRM *SpecType,
+	actualProto ProtoT,
+	specFromProto func(mapCtx *direct.MapContext, in ProtoT) *SpecType,
+	specToProto func(mapCtx *direct.MapContext, in *SpecType) ProtoT,
+	normalize func(ctx context.Context, pb ProtoT) error,
+) (*structuredreporting.Diff, *fieldmaskpb.FieldMask, error) {
+	mapCtx := &direct.MapContext{}
+
+	// Step 1: actualProto -> actualKRM (Spec_FromProto)
+	actualKRM := specFromProto(mapCtx, actualProto)
+	if err := mapCtx.Err(); err != nil {
+		return nil, nil, err
+	}
+
+	// Step 2: Merge Unspecified Fields (MergeUnsetFields)
+	// Deep copy desiredKRM via JSON to avoid mutating caller state, then merge unspecified fields from actualKRM.
+	var clonedDesiredKRM *SpecType
+	if desiredKRM != nil {
+		bytes, err := json.Marshal(desiredKRM)
+		if err != nil {
+			return nil, nil, fmt.Errorf("cloning desiredKRM: %w", err)
+		}
+		clonedDesiredKRM = new(SpecType)
+		if err := json.Unmarshal(bytes, clonedDesiredKRM); err != nil {
+			return nil, nil, fmt.Errorf("cloning desiredKRM: %w", err)
+		}
+	}
+	MergeUnsetFields(reflect.ValueOf(clonedDesiredKRM), reflect.ValueOf(actualKRM))
+
+	// Step 3: Convert KRM Specs to Protos (Spec_ToProto)
+	desiredProtoMasked := specToProto(mapCtx, clonedDesiredKRM)
+	if err := mapCtx.Err(); err != nil {
+		return nil, nil, err
+	}
+
+	actualProtoMasked := specToProto(mapCtx, actualKRM)
+	if err := mapCtx.Err(); err != nil {
+		return nil, nil, err
+	}
+
+	// Step 4: Normalization & Slice Sorting (normalize & SortRepeatedFields)
+	if normalize != nil {
+		if err := normalize(ctx, desiredProtoMasked); err != nil {
+			return nil, nil, err
+		}
+		if err := normalize(ctx, actualProtoMasked); err != nil {
+			return nil, nil, err
+		}
+	}
+	SortRepeatedFields(proto.Message(desiredProtoMasked).ProtoReflect())
+	SortRepeatedFields(proto.Message(actualProtoMasked).ProtoReflect())
+
+	// Step 5: Top-Level Diff & FieldMask Generation (DiffForTopLevelFields)
+	return DiffForTopLevelFields(ctx, proto.Message(desiredProtoMasked).ProtoReflect(), proto.Message(actualProtoMasked).ProtoReflect())
 }

--- a/pkg/controller/direct/common/compare_test.go
+++ b/pkg/controller/direct/common/compare_test.go
@@ -15,9 +15,14 @@
 package common
 
 import (
+	"context"
+	"reflect"
+	"strings"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/structuredreporting"
+
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -289,4 +294,598 @@ func stringPtr(s string) *string {
 
 func boolPtr(b bool) *bool {
 	return &b
+}
+
+type sampleKRMNestedSub struct {
+	StrVal    *string           `json:"strVal,omitempty"`
+	IntVal    *int64            `json:"intVal,omitempty"`
+	BoolVal   *bool             `json:"boolVal,omitempty"`
+	FloatVal  *float64          `json:"floatVal,omitempty"`
+	MapVal    map[string]string `json:"mapVal,omitempty"`
+	ListVal   []string          `json:"listVal,omitempty"`
+	NonPtrStr string            `json:"nonPtrStr,omitempty"`
+	NonPtrInt int64             `json:"nonPtrInt,omitempty"`
+}
+
+type sampleKRMSub struct {
+	// Nested primitive pointers
+	StrVal   *string  `json:"strVal,omitempty"`
+	IntVal   *int64   `json:"intVal,omitempty"`
+	BoolVal  *bool    `json:"boolVal,omitempty"`
+	FloatVal *float64 `json:"floatVal,omitempty"`
+
+	// Deeply nested struct pointer
+	NestedSub *sampleKRMNestedSub `json:"nestedSub,omitempty"`
+
+	// Nested maps
+	StringMap map[string]string              `json:"stringMap,omitempty"`
+	StructMap map[string]*sampleKRMNestedSub `json:"structMap,omitempty"`
+
+	// Nested slices
+	StringSlice []string              `json:"stringSlice,omitempty"`
+	StructSlice []*sampleKRMNestedSub `json:"structSlice,omitempty"`
+
+	// Non-pointer fields
+	NonPtrStr string `json:"nonPtrStr,omitempty"`
+	NonPtrInt int64  `json:"nonPtrInt,omitempty"`
+}
+
+type sampleKRMSpec struct {
+	// Top-level primitive pointers
+	StrField   *string  `json:"strField,omitempty"`
+	IntField   *int64   `json:"intField,omitempty"`
+	BoolField  *bool    `json:"boolField,omitempty"`
+	FloatField *float64 `json:"floatField,omitempty"`
+
+	// Top-level struct pointers
+	SubStruct *sampleKRMSub `json:"subStruct,omitempty"`
+
+	// Top-level maps
+	StringMap map[string]string        `json:"stringMap,omitempty"`
+	StructMap map[string]*sampleKRMSub `json:"structMap,omitempty"`
+
+	// Top-level slices
+	StringSlice []string        `json:"stringSlice,omitempty"`
+	StructSlice []*sampleKRMSub `json:"structSlice,omitempty"`
+
+	// Non-pointer fields
+	NonPtrStr string `json:"nonPtrStr,omitempty"`
+	NonPtrInt int64  `json:"nonPtrInt,omitempty"`
+}
+
+func int64Ptr(i int64) *int64 {
+	return &i
+}
+
+func float64Ptr(f float64) *float64 {
+	return &f
+}
+
+func TestMergeUnsetFields_ValidValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		desired *sampleKRMSpec
+		actual  *sampleKRMSpec
+		want    *sampleKRMSpec
+	}{
+		{
+			name: "primitive pointers: adopts actual if nil, preserves desired if non-nil",
+			desired: &sampleKRMSpec{
+				StrField: stringPtr("user-specified"),
+				// IntField, BoolField, FloatField left nil by user
+			},
+			actual: &sampleKRMSpec{
+				StrField:   stringPtr("gcp-string"),
+				IntField:   int64Ptr(42),
+				BoolField:  boolPtr(true),
+				FloatField: float64Ptr(3.14),
+			},
+			want: &sampleKRMSpec{
+				StrField:   stringPtr("user-specified"), // Preserved user value
+				IntField:   int64Ptr(42),                // Adopted actual GCP value
+				BoolField:  boolPtr(true),               // Adopted actual GCP value
+				FloatField: float64Ptr(3.14),            // Adopted actual GCP value
+			},
+		},
+		{
+			name: "nested struct pointers: merges recursively for unspecified subfields",
+			desired: &sampleKRMSpec{
+				SubStruct: &sampleKRMSub{
+					StrVal: stringPtr("user-nested-string"),
+					// IntVal, BoolVal, FloatVal left nil by user
+				},
+			},
+			actual: &sampleKRMSpec{
+				SubStruct: &sampleKRMSub{
+					StrVal:   stringPtr("gcp-nested-string"),
+					IntVal:   int64Ptr(100),
+					BoolVal:  boolPtr(false),
+					FloatVal: float64Ptr(2.718),
+				},
+			},
+			want: &sampleKRMSpec{
+				SubStruct: &sampleKRMSub{
+					StrVal:   stringPtr("user-nested-string"), // Preserved user value
+					IntVal:   int64Ptr(100),                   // Adopted actual GCP value
+					BoolVal:  boolPtr(false),                  // Adopted actual GCP value
+					FloatVal: float64Ptr(2.718),               // Adopted actual GCP value
+				},
+			},
+		},
+		{
+			name: "deeply nested structs (3 levels): merges sub-sub-fields",
+			desired: &sampleKRMSpec{
+				SubStruct: &sampleKRMSub{
+					NestedSub: &sampleKRMNestedSub{
+						StrVal: stringPtr("user-deep-string"),
+						// IntVal, BoolVal left nil
+					},
+				},
+			},
+			actual: &sampleKRMSpec{
+				SubStruct: &sampleKRMSub{
+					NestedSub: &sampleKRMNestedSub{
+						StrVal:  stringPtr("gcp-deep-string"),
+						IntVal:  int64Ptr(999),
+						BoolVal: boolPtr(true),
+					},
+				},
+			},
+			want: &sampleKRMSpec{
+				SubStruct: &sampleKRMSub{
+					NestedSub: &sampleKRMNestedSub{
+						StrVal:  stringPtr("user-deep-string"), // Preserved user value
+						IntVal:  int64Ptr(999),                 // Adopted actual GCP value
+						BoolVal: boolPtr(true),                 // Adopted actual GCP value
+					},
+				},
+			},
+		},
+		{
+			name:    "maps: adopts actual map if desired map is nil",
+			desired: &sampleKRMSpec{
+				// StringMap left nil
+			},
+			actual: &sampleKRMSpec{
+				StringMap: map[string]string{"env": "prod"},
+			},
+			want: &sampleKRMSpec{
+				StringMap: map[string]string{"env": "prod"}, // Adopted actual map
+			},
+		},
+		{
+			name: "slices: adopts actual slice if desired is nil, preserves if non-nil",
+			desired: &sampleKRMSpec{
+				StringSlice: []string{"user-item"},
+				// StructSlice left nil
+			},
+			actual: &sampleKRMSpec{
+				StringSlice: []string{"gcp-item-1", "gcp-item-2"},
+				StructSlice: []*sampleKRMSub{{StrVal: stringPtr("gcp-sub")}},
+			},
+			want: &sampleKRMSpec{
+				StringSlice: []string{"user-item"},                           // Preserved user slice
+				StructSlice: []*sampleKRMSub{{StrVal: stringPtr("gcp-sub")}}, // Adopted actual slice
+			},
+		},
+		{
+			name: "non-pointer primitive fields: remain untouched",
+			desired: &sampleKRMSpec{
+				NonPtrStr: "user-value",
+				// NonPtrInt left zero-value 0
+			},
+			actual: &sampleKRMSpec{
+				NonPtrStr: "gcp-value",
+				NonPtrInt: 999,
+			},
+			want: &sampleKRMSpec{
+				NonPtrStr: "user-value", // Preserved user non-pointer value
+				NonPtrInt: 0,            // Zero-value left untouched (not overwritten)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			MergeUnsetFields(reflect.ValueOf(tc.desired), reflect.ValueOf(tc.actual))
+			if diff := cmp.Diff(tc.want, tc.desired); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestMergeUnsetFields_InvalidValues(t *testing.T) {
+	t.Run("handles invalid reflect values safely without panic", func(t *testing.T) {
+		// Verify that invalid/zero reflect.Value inputs hit the top guard clause
+		// (if !desired.IsValid() || !actual.IsValid() { return }) and return safely.
+		MergeUnsetFields(reflect.Value{}, reflect.Value{})
+	})
+}
+
+func TestSortRepeatedFields_ValidValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		input proto.Message
+		want  proto.Message
+	}{
+		{
+			name: "sorts primitive list in structpb.ListValue",
+			input: func() proto.Message {
+				list, err := structpb.NewList([]interface{}{"banana", "apple", "cherry"})
+				if err != nil {
+					t.Fatal(err)
+				}
+				return list
+			}(),
+			want: func() proto.Message {
+				list, err := structpb.NewList([]interface{}{"apple", "banana", "cherry"})
+				if err != nil {
+					t.Fatal(err)
+				}
+				return list
+			}(),
+		},
+		{
+			name: "sorts repeated proto messages inside message",
+			input: &descriptorpb.FileDescriptorProto{
+				MessageType: []*descriptorpb.DescriptorProto{
+					{Name: stringPtr("Zebra")},
+					{Name: stringPtr("Alpha")},
+				},
+			},
+			want: &descriptorpb.FileDescriptorProto{
+				MessageType: []*descriptorpb.DescriptorProto{
+					{Name: stringPtr("Alpha")},
+					{Name: stringPtr("Zebra")},
+				},
+			},
+		},
+		{
+			name: "traverses map values with nested messages across multiple unsorted map keys",
+			input: func() proto.Message {
+				m, err := structpb.NewStruct(map[string]interface{}{
+					"z_config": map[string]interface{}{
+						"items": []interface{}{"b", "a"},
+					},
+					"a_config": map[string]interface{}{
+						"items": []interface{}{"y", "x", "z"},
+					},
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				return m
+			}(),
+			want: func() proto.Message {
+				m, err := structpb.NewStruct(map[string]interface{}{
+					"z_config": map[string]interface{}{
+						"items": []interface{}{"a", "b"},
+					},
+					"a_config": map[string]interface{}{
+						"items": []interface{}{"x", "y", "z"},
+					},
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				return m
+			}(),
+		},
+		{
+			name: "sorts nested lists inside elements of a list",
+			input: &descriptorpb.FileDescriptorProto{
+				MessageType: []*descriptorpb.DescriptorProto{
+					{
+						Name: stringPtr("Zebra"),
+						Field: []*descriptorpb.FieldDescriptorProto{
+							{Name: stringPtr("z_field_2")},
+							{Name: stringPtr("z_field_1")},
+						},
+					},
+					{
+						Name: stringPtr("Alpha"),
+						Field: []*descriptorpb.FieldDescriptorProto{
+							{Name: stringPtr("a_field_2")},
+							{Name: stringPtr("a_field_1")},
+						},
+					},
+				},
+			},
+			want: &descriptorpb.FileDescriptorProto{
+				MessageType: []*descriptorpb.DescriptorProto{
+					{
+						Name: stringPtr("Alpha"),
+						Field: []*descriptorpb.FieldDescriptorProto{
+							{Name: stringPtr("a_field_1")},
+							{Name: stringPtr("a_field_2")},
+						},
+					},
+					{
+						Name: stringPtr("Zebra"),
+						Field: []*descriptorpb.FieldDescriptorProto{
+							{Name: stringPtr("z_field_1")},
+							{Name: stringPtr("z_field_2")},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			SortRepeatedFields(tc.input.ProtoReflect())
+			if diff := cmp.Diff(tc.want, tc.input, protocmp.Transform()); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSortRepeatedFields_InvalidValues(t *testing.T) {
+	t.Run("handles nil message safely without panic", func(t *testing.T) {
+		// Verify that nil protoreflect.Message hits the guard clause (if msg == nil || !msg.IsValid()) and returns safely.
+		SortRepeatedFields(nil)
+	})
+}
+
+// TestCompareBrownfieldSpec tests the 5-step brownfield reconciliation workflow.
+// We use *descriptorpb.FileDescriptorProto as the test ProtoT message because it is a standard
+// library proto.Message with a rich variety of fields (primitives, top-level slices, sub-messages, booleans, and options)
+// to exercise reflection, merging, normalization, and fieldmask generation hermetically.
+func TestCompareBrownfieldSpec(t *testing.T) {
+	// specFromProto maps from GCP live state (*descriptorpb.FileDescriptorProto) to KRM spec (*sampleKRMSpec):
+	//   - in.Name                        -> res.StrField
+	//   - in.GetPackage()                -> res.NonPtrStr
+	//   - in.Options.Deprecated          -> res.BoolField
+	//   - in.Service[0].Name             -> res.SubStruct.StrVal
+	//   - in.MessageType[i].GetName()    -> res.StringSlice[i] (top-level repeated slice entry)
+	//   - in.Options.UninterpretedOption -> res.StringMap
+	specFromProto := func(mapCtx *direct.MapContext, in *descriptorpb.FileDescriptorProto) *sampleKRMSpec {
+		if in == nil {
+			return nil
+		}
+		res := &sampleKRMSpec{
+			StrField:  in.Name,
+			NonPtrStr: in.GetPackage(),
+		}
+		if in.Options != nil && in.Options.Deprecated != nil {
+			val := *in.Options.Deprecated
+			res.BoolField = &val
+		}
+		if len(in.Service) > 0 {
+			res.SubStruct = &sampleKRMSub{
+				StrVal: in.Service[0].Name,
+			}
+		}
+		if len(in.MessageType) > 0 {
+			for _, m := range in.MessageType {
+				res.StringSlice = append(res.StringSlice, m.GetName())
+			}
+		}
+		if in.Options != nil && len(in.Options.UninterpretedOption) > 0 {
+			res.StringMap = make(map[string]string)
+			for _, opt := range in.Options.UninterpretedOption {
+				if len(opt.Name) > 0 {
+					key := opt.Name[0].GetNamePart()
+					val := string(opt.GetStringValue())
+					res.StringMap[key] = val
+				}
+			}
+		}
+		return res
+	}
+
+	// specToProto maps from KRM spec (*sampleKRMSpec) to GCP desired state (*descriptorpb.FileDescriptorProto):
+	//   - in.StrField                    -> res.Name
+	//   - in.NonPtrStr                   -> res.Package
+	//   - in.BoolField                   -> res.Options.Deprecated
+	//   - in.SubStruct.StrVal            -> res.Service[0].Name
+	//   - in.StringSlice[i]              -> res.MessageType[i].Name (top-level repeated slice entry)
+	//   - in.StringMap                   -> res.Options.UninterpretedOption
+	specToProto := func(mapCtx *direct.MapContext, in *sampleKRMSpec) *descriptorpb.FileDescriptorProto {
+		if in == nil {
+			return nil
+		}
+		res := &descriptorpb.FileDescriptorProto{
+			Name:    in.StrField,
+			Package: stringPtr(in.NonPtrStr),
+		}
+		if in.SubStruct != nil && in.SubStruct.StrVal != nil {
+			res.Service = []*descriptorpb.ServiceDescriptorProto{
+				{Name: in.SubStruct.StrVal},
+			}
+		}
+		if len(in.StringSlice) > 0 {
+			for _, s := range in.StringSlice {
+				res.MessageType = append(res.MessageType, &descriptorpb.DescriptorProto{
+					Name: stringPtr(s),
+				})
+			}
+		}
+		if in.BoolField != nil || len(in.StringMap) > 0 {
+			res.Options = &descriptorpb.FileOptions{}
+			if in.BoolField != nil {
+				res.Options.Deprecated = in.BoolField
+			}
+			for k, v := range in.StringMap {
+				res.Options.UninterpretedOption = append(res.Options.UninterpretedOption, &descriptorpb.UninterpretedOption{
+					Name: []*descriptorpb.UninterpretedOption_NamePart{
+						{NamePart: stringPtr(k)},
+					},
+					StringValue: []byte(v),
+				})
+			}
+		}
+		return res
+	}
+
+	tests := []struct {
+		name               string
+		desiredKRM         *sampleKRMSpec
+		actualProto        *descriptorpb.FileDescriptorProto
+		specFromProtoErr   bool
+		normalize          func(ctx context.Context, pb *descriptorpb.FileDescriptorProto) error
+		wantHasDiff        bool
+		wantFieldMaskPaths sets.Set[string]
+		wantErr            bool
+	}{
+		{
+			name: "unspecified KRM fields adopt live GCP state across primitive, nested struct, map, and top-level slice fields (no diff)",
+			desiredKRM: &sampleKRMSpec{
+				StrField:  stringPtr("my-resource"),
+				NonPtrStr: "non-ptr-value",
+				// SubStruct, StringMap, StringSlice left nil by user
+			},
+			actualProto: &descriptorpb.FileDescriptorProto{
+				Name:    stringPtr("my-resource"),   // maps to StrField
+				Package: stringPtr("non-ptr-value"), // maps to NonPtrStr
+				Service: []*descriptorpb.ServiceDescriptorProto{
+					{Name: stringPtr("gcp-service-name")}, // maps to SubStruct.StrVal
+				},
+				MessageType: []*descriptorpb.DescriptorProto{
+					{Name: stringPtr("Alpha")}, // maps to StringSlice (top-level repeated slice)
+					{Name: stringPtr("Zebra")},
+				},
+				Options: &descriptorpb.FileOptions{
+					Deprecated: boolPtr(true), // maps to BoolField
+					UninterpretedOption: []*descriptorpb.UninterpretedOption{
+						{
+							Name: []*descriptorpb.UninterpretedOption_NamePart{
+								{NamePart: stringPtr("env")}, // maps to StringMap["env"]
+							},
+							StringValue: []byte("prod"),
+						},
+					},
+				},
+			},
+			normalize:          nil, // SortRepeatedFields runs automatically in CompareBrownfieldSpec Step 4
+			wantHasDiff:        false,
+			wantFieldMaskPaths: sets.New[string](),
+		},
+		{
+			name: "user updates nested struct field in KRM, producing a diff on that field",
+			desiredKRM: &sampleKRMSpec{
+				StrField: stringPtr("my-resource"),
+				SubStruct: &sampleKRMSub{
+					StrVal: stringPtr("user-updated-service-name"), // Changed from live GCP state ("old-gcp-service-name")
+				},
+			},
+			actualProto: &descriptorpb.FileDescriptorProto{
+				Name: stringPtr("my-resource"), // maps to StrField (unchanged)
+				Service: []*descriptorpb.ServiceDescriptorProto{
+					{Name: stringPtr("old-gcp-service-name")}, // maps to SubStruct.StrVal (differs: "old-gcp-service-name" vs "user-updated-service-name")
+				},
+			},
+			normalize:          nil, // Callers pass nil when no custom normalization is needed
+			wantHasDiff:        true,
+			wantFieldMaskPaths: sets.New("service"),
+		},
+		{
+			name: "normalize hook normalizes specific field values (e.g. lowercasing strings), preventing false diffs",
+			desiredKRM: &sampleKRMSpec{
+				StrField: stringPtr("MY-RESOURCE-NAME"), // Upper-case in KRM
+			},
+			actualProto: &descriptorpb.FileDescriptorProto{
+				Name: stringPtr("my-resource-name"), // maps to StrField (lowercased during normalize hook)
+			},
+			normalize: func(ctx context.Context, pb *descriptorpb.FileDescriptorProto) error {
+				// Normalize hook active: lowercases field values in desired and actual proto to handle case-insensitivity
+				if pb.Name != nil {
+					lower := strings.ToLower(*pb.Name)
+					pb.Name = &lower
+				}
+				return nil
+			},
+			wantHasDiff:        false,
+			wantFieldMaskPaths: sets.New[string](),
+		},
+		{
+			name: "automatically sorts top-level slice entries when desired KRM slice order differs from actual GCP proto order (no diff)",
+			desiredKRM: &sampleKRMSpec{
+				StrField:    stringPtr("my-resource"),
+				StringSlice: []string{"Zebra", "Alpha"}, // Unsorted order in KRM
+			},
+			actualProto: &descriptorpb.FileDescriptorProto{
+				Name: stringPtr("my-resource"), // maps to StrField
+				MessageType: []*descriptorpb.DescriptorProto{ // maps to StringSlice (top-level repeated slice)
+					{Name: stringPtr("Alpha")},
+					{Name: stringPtr("Zebra")},
+				},
+			},
+			normalize:          nil, // CompareBrownfieldSpec automatically sorts repeated fields without needing a custom normalize func
+			wantHasDiff:        false,
+			wantFieldMaskPaths: sets.New[string](),
+		},
+		{
+			name: "specFromProto error is reported cleanly",
+			desiredKRM: &sampleKRMSpec{
+				StrField: stringPtr("my-resource"),
+			},
+			actualProto: &descriptorpb.FileDescriptorProto{
+				Name: stringPtr("my-resource"), // maps to StrField
+			},
+			specFromProtoErr: true,
+			normalize:        nil,
+			wantErr:          true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fromProto := func(mapCtx *direct.MapContext, in *descriptorpb.FileDescriptorProto) *sampleKRMSpec {
+				if tc.specFromProtoErr {
+					mapCtx.Errorf("simulated specFromProto mapping failure")
+					return nil
+				}
+				return specFromProto(mapCtx, in)
+			}
+
+			toProto := func(mapCtx *direct.MapContext, in *sampleKRMSpec) *descriptorpb.FileDescriptorProto {
+				return specToProto(mapCtx, in)
+			}
+
+			diff, fieldMask, err := CompareBrownfieldSpec(
+				t.Context(),
+				tc.desiredKRM,
+				tc.actualProto,
+				fromProto,
+				toProto,
+				tc.normalize,
+			)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tc.wantHasDiff {
+				if diff == nil || !diff.HasDiff() {
+					t.Errorf("expected diff, got no diff")
+				}
+			} else {
+				if diff != nil && diff.HasDiff() {
+					t.Errorf("expected no diff, got diff:\n%+v", diff)
+				}
+			}
+
+			if fieldMask == nil {
+				t.Fatalf("expected non-nil fieldMask")
+			}
+
+			if tc.wantFieldMaskPaths != nil {
+				paths := sets.New(fieldMask.GetPaths()...)
+				if !paths.Equal(tc.wantFieldMaskPaths) {
+					t.Errorf("fieldmask paths mismatch: want %v, got %v", tc.wantFieldMaskPaths, paths)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
### BRIEF Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Introduced `common.CompareBrownfieldSpec` to standardize brownfield diff calculation in direct controllers. When managing brownfield GCP resources, unspecified fields in a user's KRM spec should adopt the existing values from live GCP state rather than causing unwanted drifts or wipes.

The 5-step diffing workflow can be found at docs/design-decisions/brownfield-diff-reconciliation.md.

Based on the design, I implemented the helper functions and corresponding unit tests.

#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
