### PR TITLE
Ignore diff for specificReservation.inUseCount in ComputeReservation

### DIFF
--- a/apis/compute/v1beta1/computereservation_types.go
+++ b/apis/compute/v1beta1/computereservation_types.go
@@ -58,6 +58,7 @@ type ReservationSpecificReservation struct {
 	// +kcc:proto:field=google.cloud.compute.v1.AllocationSpecificSKUReservation.count
 	Count *int64 `json:"count"`
 
+	// Output only. Setting this field has no effect.
 	// How many instances are in use.
 	// +kcc:proto:field=google.cloud.compute.v1.AllocationSpecificSKUReservation.in_use_count
 	InUseCount *int64 `json:"inUseCount,omitempty"`

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_computereservations.compute.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_computereservations.compute.cnrm.cloud.google.com.yaml
@@ -167,7 +167,8 @@ spec:
                     format: int64
                     type: integer
                   inUseCount:
-                    description: How many instances are in use.
+                    description: Output only. Setting this field has no effect. How
+                      many instances are in use.
                     format: int64
                     type: integer
                   instanceProperties:

--- a/pkg/controller/direct/compute/computereservation_controller.go
+++ b/pkg/controller/direct/compute/computereservation_controller.go
@@ -430,7 +430,10 @@ func (a *ReservationAdapter) assignGCPDefaults(desired *computepb.Reservation, a
 		actual.GetShareSettings().GetShareType() == "LOCAL" {
 		desired.ShareSettings = actual.ShareSettings
 	}
-	if desired.SpecificReservation != nil && desired.SpecificReservation.AssuredCount == nil {
-		desired.SpecificReservation.AssuredCount = actual.SpecificReservation.AssuredCount
+	if desired.SpecificReservation != nil && actual.SpecificReservation != nil {
+		if desired.SpecificReservation.AssuredCount == nil {
+			desired.SpecificReservation.AssuredCount = actual.SpecificReservation.AssuredCount
+		}
+		desired.SpecificReservation.InUseCount = actual.SpecificReservation.InUseCount
 	}
 }

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computereservation.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computereservation.md
@@ -317,7 +317,7 @@ zone: string
         </td>
         <td>
             <p><code class="apitype">integer</code></p>
-            <p>How many instances are in use.</p>
+            <p>Output only. Setting this field has no effect. How many instances are in use.</p>
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
### BRIEF Change description

specificReservation.inUseCount is a output only field; set the field to gcp returned value before comparing diff.

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Fixes #12175

#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
