### PR TITLE
Support canonicalization for Compute network values

### DIFF
--- a/apis/common/projects/mapper.go
+++ b/apis/common/projects/mapper.go
@@ -206,6 +206,9 @@ func (c *ProjectCache) queryForProject(ctx context.Context, name string) (*cache
 	req := &resourcemanagerpb.GetProjectRequest{
 		Name: name,
 	}
+	if c.client == nil {
+		return nil, fmt.Errorf("project cache client is nil; cannot lookup project %q", req.Name)
+	}
 	project, err := c.client.GetProject(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("error getting project %q: %w", req.Name, err)
@@ -226,4 +229,15 @@ func (c *ProjectCache) queryForProject(ctx context.Context, name string) (*cache
 		projectNumber: projectNumber,
 		timestamp:     time.Now(),
 	}, nil
+}
+
+// InsertForTest inserts a project ID to project number mapping into the cache for testing purposes.
+func (c *ProjectCache) InsertForTest(projectID string, projectNumber int64) {
+	info := &cachedProjectInfo{
+		projectID:     projectID,
+		projectNumber: projectNumber,
+		timestamp:     time.Now(),
+	}
+	c.projectsByID.Set(projectID, info)
+	c.projectsByNumber.Set(projectNumber, info)
 }

--- a/apis/compute/refs/computenetwork_identity.go
+++ b/apis/compute/refs/computenetwork_identity.go
@@ -39,6 +39,10 @@ func (i *ComputeNetworkIdentity) String() string {
 	return ComputeNetworkIdentityFormat.ToString(*i)
 }
 
+// FromExternal parses ref into a ComputeNetworkIdentity.
+// It supports full HTTPS URIs ("https://www.googleapis.com/compute/v1/projects/{project}/global/networks/{network}")
+// and relative resource names ("projects/{project}/global/networks/{network}").
+// Raw short names (e.g. "my-vpc") are not valid external references until canonicalized via CanonicalizeExternal.
 func (i *ComputeNetworkIdentity) FromExternal(ref string) error {
 	trimmedRef := apirefs.TrimComputeURIPrefix(ref)
 	parsed, match, err := ComputeNetworkIdentityFormat.Parse(trimmedRef)

--- a/apis/compute/refs/computenetwork_reference.go
+++ b/apis/compute/refs/computenetwork_reference.go
@@ -31,6 +31,7 @@ import (
 	refsv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -45,6 +46,10 @@ var _ refsv1beta1.Ref = &ComputeNetworkRef{}
 // ComputeNetworkRef is a reference to a GCP ComputeNetwork.
 // +k8s:deepcopy-gen=true
 type ComputeNetworkRef struct {
+	// For backward compatibility, the external value can also be full URIs
+	// (e.g. "https://www.googleapis.com/compute/v1/projects/{{projectID}}/global/networks/{{networkID}}")
+	// or short names (e.g. "my-vpc").
+
 	// A reference to an externally managed ComputeNetwork resource.
 	// Should be in the format "projects/{{projectID}}/global/networks/{{networkID}}".
 	External string `json:"external,omitempty"`
@@ -81,6 +86,45 @@ func (r *ComputeNetworkRef) SetExternal(ref string) {
 	r.Namespace = ""
 }
 
+// CanonicalizeNetworkValue transforms any raw network string (full URI, short name, or relative path with project number)
+// into a canonical relative path: "projects/{projectID}/global/networks/{network}".
+func CanonicalizeNetworkValue(ctx context.Context, val string, parentProjectID string, projectMapper *projects.ProjectMapper) string {
+	if val == "" {
+		return ""
+	}
+
+	// 1. Trim scheme & domain prefix
+	trimmed := apirefs.TrimComputeURIPrefix(val)
+
+	// 2. Expand short names (no slashes) using parentProjectID
+	if !strings.Contains(trimmed, "/") {
+		if parentProjectID == "" {
+			klog.V(2).Infof("cannot canonicalize short network name %q without parent project ID", val)
+			return val
+		}
+		trimmed = fmt.Sprintf("projects/%s/global/networks/%s", parentProjectID, trimmed)
+	}
+
+	// 3. Use FromExternal() to parse and validate the network value
+	id := &ComputeNetworkIdentity{}
+	if err := id.FromExternal(trimmed); err != nil {
+		return trimmed
+	}
+
+	// 4. Resolve numeric Project Number to Project ID if projectMapper is available
+	if projectMapper != nil && id.Project != "" {
+		if projectID, err := projectMapper.ReplaceProjectNumberWithID(ctx, id.Project); err == nil {
+			id.Project = projectID
+		}
+	}
+
+	return id.String()
+}
+
+// ValidateExternal checks if ref is a valid external reference format.
+// It supports full HTTPS URIs ("https://www.googleapis.com/compute/v1/projects/{project}/global/networks/{network}")
+// and relative resource names ("projects/{project}/global/networks/{network}").
+// Raw short names (e.g. "my-vpc") are not valid external references until canonicalized via CanonicalizeExternal.
 func (r *ComputeNetworkRef) ValidateExternal(ref string) error {
 	trimmedRef := apirefs.TrimComputeURIPrefix(ref)
 	id := &ComputeNetworkIdentity{}

--- a/apis/compute/refs/computenetwork_reference.go
+++ b/apis/compute/refs/computenetwork_reference.go
@@ -86,9 +86,9 @@ func (r *ComputeNetworkRef) SetExternal(ref string) {
 	r.Namespace = ""
 }
 
-// CanonicalizeNetworkValue transforms any raw network string (full URI, short name, or relative path with project number)
+// canonicalizeNetworkValue transforms any raw network string (full URI, short name, or relative path with project number)
 // into a canonical relative path: "projects/{projectID}/global/networks/{network}".
-func CanonicalizeNetworkValue(ctx context.Context, val string, parentProjectID string, projectMapper *projects.ProjectMapper) string {
+func canonicalizeNetworkValue(ctx context.Context, val string, parentProjectID string, projectMapper *projects.ProjectMapper) string {
 	if val == "" {
 		return ""
 	}
@@ -142,6 +142,7 @@ func (r *ComputeNetworkRef) ParseExternalToIdentity() (identity.Identity, error)
 	return id, nil
 }
 
+// Normalize resolves internal Kubernetes references or normalizes the external reference format.
 func (r *ComputeNetworkRef) Normalize(ctx context.Context, reader client.Reader, defaultNamespace string) error {
 	if r.External != "" {
 		r.External = apirefs.TrimComputeURIPrefix(r.External)
@@ -156,6 +157,16 @@ func (r *ComputeNetworkRef) Normalize(ctx context.Context, reader client.Reader,
 		return ""
 	}
 	return refsv1beta1.NormalizeWithFallback(ctx, reader, r, defaultNamespace, fallback)
+}
+
+// CanonicalizeAndNormalize canonicalizes raw network formats (such as short names or full HTTPS URIs)
+// and normalizes Kubernetes/external references in a single step.
+func (r *ComputeNetworkRef) CanonicalizeAndNormalize(ctx context.Context, reader client.Reader, defaultNamespace string, parentProjectID string, projectMapper *projects.ProjectMapper) error {
+	if r == nil {
+		return nil
+	}
+	r.External = canonicalizeNetworkValue(ctx, r.External, parentProjectID, projectMapper)
+	return r.Normalize(ctx, reader, defaultNamespace)
 }
 
 func (id *ComputeNetworkIdentity) ConvertToProjectNumber(ctx context.Context, projectMapper *projects.ProjectMapper) error {

--- a/apis/compute/refs/computenetwork_reference_test.go
+++ b/apis/compute/refs/computenetwork_reference_test.go
@@ -159,10 +159,107 @@ func TestCanonicalizeNetworkValue(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.TODO()
-			got := CanonicalizeNetworkValue(ctx, tc.val, tc.parentProjectID, projectMapper)
+			got := canonicalizeNetworkValue(ctx, tc.val, tc.parentProjectID, projectMapper)
 			if got != tc.want {
-				t.Errorf("CanonicalizeNetworkValue(%q, %q) = %q, want %q", tc.val, tc.parentProjectID, got, tc.want)
+				t.Errorf("canonicalizeNetworkValue(%q, %q) = %q, want %q", tc.val, tc.parentProjectID, got, tc.want)
 			}
 		})
 	}
 }
+
+func TestCanonicalizeAndNormalize(t *testing.T) {
+	cache := projects.NewProjectCache(nil, time.Hour)
+	cache.InsertForTest("my-project", 12345)
+	projectMapper := projects.NewProjectMapper(cache)
+
+	tests := []struct {
+		name            string
+		ref             *ComputeNetworkRef
+		unstructured    *unstructured.Unstructured
+		parentProjectID string
+		want            *ComputeNetworkRef
+	}{
+		{
+			name: "nil ref",
+			ref:  nil,
+			want: nil,
+		},
+		{
+			name: "short name with parent project",
+			ref: &ComputeNetworkRef{
+				External: "default",
+			},
+			parentProjectID: "my-project",
+			want: &ComputeNetworkRef{
+				External: "projects/my-project/global/networks/default",
+			},
+		},
+		{
+			name: "full HTTPS URI",
+			ref: &ComputeNetworkRef{
+				External: "https://www.googleapis.com/compute/v1/projects/my-project/global/networks/my-vpc",
+			},
+			parentProjectID: "other-project",
+			want: &ComputeNetworkRef{
+				External: "projects/my-project/global/networks/my-vpc",
+			},
+		},
+		{
+			name: "project number in external resolved to project ID",
+			ref: &ComputeNetworkRef{
+				External: "projects/12345/global/networks/my-vpc",
+			},
+			want: &ComputeNetworkRef{
+				External: "projects/my-project/global/networks/my-vpc",
+			},
+		},
+		{
+			name: "k8s object reference",
+			ref: &ComputeNetworkRef{
+				Name:      "n1",
+				Namespace: "ns1",
+			},
+			unstructured: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"status": map[string]interface{}{
+						"selfLink": "https://www.googleapis.com/compute/v1/projects/p1/global/networks/n1",
+					},
+				},
+			},
+			parentProjectID: "other-project",
+			want: &ComputeNetworkRef{
+				External: "projects/p1/global/networks/n1",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.TODO()
+
+			var objs []unstructured.Unstructured
+			if tc.unstructured != nil && tc.ref != nil {
+				tc.unstructured.SetName(tc.ref.Name)
+				tc.unstructured.SetNamespace(tc.ref.Namespace)
+				tc.unstructured.SetGroupVersionKind(ComputeNetworkGVK)
+				objs = append(objs, *tc.unstructured)
+			}
+
+			s := fake.NewClientBuilder().WithLists(&unstructured.UnstructuredList{Items: objs}).Build()
+
+			defaultNamespace := ""
+			if tc.ref != nil {
+				defaultNamespace = tc.ref.Namespace
+			}
+
+			if err := tc.ref.CanonicalizeAndNormalize(ctx, s, defaultNamespace, tc.parentProjectID, projectMapper); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.ref, tc.want); diff != "" {
+				t.Errorf("CanonicalizeAndNormalize() mismatch (-got +want):\n%s", diff)
+			}
+		})
+	}
+}
+

--- a/apis/compute/refs/computenetwork_reference_test.go
+++ b/apis/compute/refs/computenetwork_reference_test.go
@@ -17,6 +17,9 @@ package computerefs
 import (
 	"context"
 	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/common/projects"
 
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -88,6 +91,77 @@ func TestComputeNetworkRefNormalize(t *testing.T) {
 
 			if diff := cmp.Diff(tc.ref, tc.want); diff != "" {
 				t.Errorf("Normalize() mismatch (-got +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCanonicalizeNetworkValue(t *testing.T) {
+	tests := []struct {
+		name            string
+		val             string
+		parentProjectID string
+		want            string
+	}{
+		{
+			name: "empty string",
+			val:  "",
+			want: "",
+		},
+		{
+			name:            "short network name with parent project",
+			val:             "default",
+			parentProjectID: "my-project",
+			want:            "projects/my-project/global/networks/default",
+		},
+		{
+			name:            "short network name without parent project",
+			val:             "default",
+			parentProjectID: "",
+			want:            "default",
+		},
+		{
+			name:            "relative resource path",
+			val:             "projects/my-project/global/networks/my-vpc",
+			parentProjectID: "other-project",
+			want:            "projects/my-project/global/networks/my-vpc",
+		},
+		{
+			name:            "full HTTPS URI",
+			val:             "https://www.googleapis.com/compute/v1/projects/my-project/global/networks/my-vpc",
+			parentProjectID: "other-project",
+			want:            "projects/my-project/global/networks/my-vpc",
+		},
+		{
+			name:            "invalid external format",
+			val:             "projects/my-project/invalid/path",
+			parentProjectID: "my-project",
+			want:            "projects/my-project/invalid/path",
+		},
+		{
+			name:            "project number present in mapper cache",
+			val:             "projects/12345/global/networks/my-vpc",
+			parentProjectID: "",
+			want:            "projects/my-project/global/networks/my-vpc",
+		},
+		{
+			name:            "project number not in mapper cache",
+			val:             "projects/99999/global/networks/my-vpc",
+			parentProjectID: "",
+			want:            "projects/99999/global/networks/my-vpc",
+		},
+	}
+
+	cache := projects.NewProjectCache(nil, time.Hour)
+	cache.InsertForTest("my-project", 12345)
+	projectMapper := projects.NewProjectMapper(cache)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.TODO()
+			got := CanonicalizeNetworkValue(ctx, tc.val, tc.parentProjectID, projectMapper)
+			if got != tc.want {
+				t.Errorf("CanonicalizeNetworkValue(%q, %q) = %q, want %q", tc.val, tc.parentProjectID, got, tc.want)
 			}
 		})
 	}

--- a/apis/compute/refs/computenetwork_reference_test.go
+++ b/apis/compute/refs/computenetwork_reference_test.go
@@ -262,4 +262,3 @@ func TestCanonicalizeAndNormalize(t *testing.T) {
 		})
 	}
 }
-


### PR DESCRIPTION
### BRIEF Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
- Added `CanonicalizeAndNormalize(ctx, reader, defaultNamespace, parentProjectID, projectMapper)` method to `ComputeNetworkRef` to combine network canonicalization (expanding short names, stripping URI prefixes, and converting project numbers) and Kubernetes reference normalization into a single call.
- Made the internal helper `canonicalizeNetworkValue` unexported.
- Added comprehensive unit tests in `computenetwork_reference_test.go` covering `canonicalizeNetworkValue` edge cases and `CanonicalizeAndNormalize` round-trip resolutions.

#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
