### PR TITLE
composer: fix environment update failures for scheduled snapshots and triggered count

### DIFF
--- a/mockgcp/mockcomposer/environment.go
+++ b/mockgcp/mockcomposer/environment.go
@@ -132,10 +132,43 @@ func (s *ComposerV1) UpdateEnvironment(ctx context.Context, req *pb.UpdateEnviro
 		switch tokens[0] {
 		case "labels":
 			updated.Labels = req.GetEnvironment().GetLabels()
+		case "config":
+			if len(tokens) < 2 {
+				return nil, status.Errorf(codes.InvalidArgument, "invalid config path %q", path)
+			}
+			if updated.Config == nil {
+				updated.Config = &pb.EnvironmentConfig{}
+			}
+			switch tokens[1] {
+			case "recoveryConfig":
+				if len(tokens) == 3 && tokens[2] == "scheduledSnapshotsConfig" {
+					if updated.Config.RecoveryConfig == nil {
+						updated.Config.RecoveryConfig = &pb.RecoveryConfig{}
+					}
+					updated.Config.RecoveryConfig.ScheduledSnapshotsConfig = req.GetEnvironment().GetConfig().GetRecoveryConfig().GetScheduledSnapshotsConfig()
+				} else {
+					return nil, status.Errorf(codes.InvalidArgument, "update_mask path %q not supported in mock", path)
+				}
+			case "workloadsConfig":
+				if len(tokens) == 4 && tokens[2] == "triggerer" && tokens[3] == "count" {
+					if updated.Config.WorkloadsConfig == nil {
+						updated.Config.WorkloadsConfig = &pb.WorkloadsConfig{}
+					}
+					if updated.Config.WorkloadsConfig.Triggerer == nil {
+						updated.Config.WorkloadsConfig.Triggerer = &pb.WorkloadsConfig_TriggererResource{}
+					}
+					updated.Config.WorkloadsConfig.Triggerer.Count = req.GetEnvironment().GetConfig().GetWorkloadsConfig().GetTriggerer().GetCount()
+				} else {
+					return nil, status.Errorf(codes.InvalidArgument, "update_mask path %q not supported in mock", path)
+				}
+			default:
+				return nil, status.Errorf(codes.InvalidArgument, "update_mask path %q not supported in mock", path)
+			}
 		default:
 			return nil, status.Errorf(codes.InvalidArgument, "update_mask path %q not valid", path)
 		}
 	}
+
 	updated.UpdateTime = timestamppb.New(now)
 	if err := s.storage.Update(ctx, fqn, updated); err != nil {
 		return nil, err

--- a/pkg/controller/direct/composer/environment_controller.go
+++ b/pkg/controller/direct/composer/environment_controller.go
@@ -17,6 +17,7 @@ package composer
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	gcp "cloud.google.com/go/orchestration/airflow/service/apiv1"
 	composerpb "cloud.google.com/go/orchestration/airflow/service/apiv1/servicepb"
@@ -183,12 +184,13 @@ func (a *EnvironmentAdapter) Update(ctx context.Context, updateOp *directbase.Up
 		return mapCtx.Err()
 	}
 	desiredPb.Name = a.id.String()
-	populateDefaultsForEnvironment(desiredPb, a.actual)
+	populateDefaultsForEnvironment(desiredPb, a.actual, desired)
 
 	paths, err := common.CompareProtoMessage(desiredPb, a.actual, common.BasicDiff)
 	if err != nil {
 		return err
 	}
+	paths = collapsePaths(paths)
 
 	if len(paths) == 0 {
 		log.V(2).Info("no field needs update", "name", a.id)
@@ -283,7 +285,7 @@ func (a *EnvironmentAdapter) Delete(ctx context.Context, deleteOp *directbase.De
 	return true, nil
 }
 
-func populateDefaultsForEnvironment(desired, actual *composerpb.Environment) {
+func populateDefaultsForEnvironment(desired, actual *composerpb.Environment, desiredKRM *krm.ComposerEnvironment) {
 	if actual == nil {
 		return
 	}
@@ -301,10 +303,14 @@ func populateDefaultsForEnvironment(desired, actual *composerpb.Environment) {
 	if desired.Config == nil && actual.Config != nil {
 		desired.Config = &composerpb.EnvironmentConfig{}
 	}
-	populateDefaultsForEnvironmentConfig(desired.Config, actual.Config)
+	var desiredConfigKRM *krm.EnvironmentConfig
+	if desiredKRM != nil {
+		desiredConfigKRM = desiredKRM.Spec.Config
+	}
+	populateDefaultsForEnvironmentConfig(desired.Config, actual.Config, desiredConfigKRM)
 }
 
-func populateDefaultsForEnvironmentConfig(desired, actual *composerpb.EnvironmentConfig) {
+func populateDefaultsForEnvironmentConfig(desired, actual *composerpb.EnvironmentConfig, desiredKRM *krm.EnvironmentConfig) {
 	if actual == nil {
 		return // If actual is nil, nothing to populate from.
 	}
@@ -339,21 +345,6 @@ func populateDefaultsForEnvironmentConfig(desired, actual *composerpb.Environmen
 			}
 		}
 	}
-
-	//if actual.DatabaseConfig != nil {
-	//	if desired.DatabaseConfig == nil {
-	//		desired.DatabaseConfig = &pb.DatabaseConfig{}
-	//	}
-	//	if desired.DatabaseConfig.MachineType == "" && actual.DatabaseConfig.MachineType != "" {
-	//		desired.DatabaseConfig.MachineType = actual.DatabaseConfig.MachineType
-	//	}
-	//}
-
-	//if actual.EncryptionConfig != nil {
-	//	if desired.EncryptionConfig == nil {
-	//		desired.EncryptionConfig = &pb.EncryptionConfig{}
-	//	}
-	//}
 
 	if desired.EnvironmentSize == composerpb.EnvironmentConfig_ENVIRONMENT_SIZE_UNSPECIFIED {
 		desired.EnvironmentSize = actual.EnvironmentSize
@@ -447,7 +438,114 @@ func populateDefaultsForEnvironmentConfig(desired, actual *composerpb.Environmen
 	if desired.WebServerNetworkAccessControl == nil {
 		desired.WebServerNetworkAccessControl = actual.WebServerNetworkAccessControl
 	}
-	if desired.WorkloadsConfig == nil {
+
+	if desired.WorkloadsConfig == nil && actual.WorkloadsConfig != nil {
 		desired.WorkloadsConfig = actual.WorkloadsConfig
+	} else if desired.WorkloadsConfig != nil && actual.WorkloadsConfig != nil {
+		var desiredWorkloadsKRM *krm.WorkloadsConfig
+		if desiredKRM != nil {
+			desiredWorkloadsKRM = desiredKRM.WorkloadsConfig
+		}
+		populateDefaultsForWorkloadsConfig(desired.WorkloadsConfig, actual.WorkloadsConfig, desiredWorkloadsKRM)
 	}
+}
+
+func populateDefaultsForWorkloadsConfig(desired, actual *composerpb.WorkloadsConfig, desiredKRM *krm.WorkloadsConfig) {
+	if actual == nil {
+		return
+	}
+
+	if desired.Scheduler == nil && actual.Scheduler != nil {
+		desired.Scheduler = proto.Clone(actual.Scheduler).(*composerpb.WorkloadsConfig_SchedulerResource)
+	} else if desired.Scheduler != nil && actual.Scheduler != nil && desiredKRM != nil && desiredKRM.Scheduler != nil {
+		if desiredKRM.Scheduler.CPU == nil {
+			desired.Scheduler.Cpu = actual.Scheduler.Cpu
+		}
+		if desiredKRM.Scheduler.MemoryGB == nil {
+			desired.Scheduler.MemoryGb = actual.Scheduler.MemoryGb
+		}
+		if desiredKRM.Scheduler.StorageGB == nil {
+			desired.Scheduler.StorageGb = actual.Scheduler.StorageGb
+		}
+		if desiredKRM.Scheduler.Count == nil {
+			desired.Scheduler.Count = actual.Scheduler.Count
+		}
+	}
+
+	if desired.WebServer == nil && actual.WebServer != nil {
+		desired.WebServer = proto.Clone(actual.WebServer).(*composerpb.WorkloadsConfig_WebServerResource)
+	} else if desired.WebServer != nil && actual.WebServer != nil && desiredKRM != nil && desiredKRM.WebServer != nil {
+		if desiredKRM.WebServer.CPU == nil {
+			desired.WebServer.Cpu = actual.WebServer.Cpu
+		}
+		if desiredKRM.WebServer.MemoryGB == nil {
+			desired.WebServer.MemoryGb = actual.WebServer.MemoryGb
+		}
+		if desiredKRM.WebServer.StorageGB == nil {
+			desired.WebServer.StorageGb = actual.WebServer.StorageGb
+		}
+	}
+
+	if desired.Worker == nil && actual.Worker != nil {
+		desired.Worker = proto.Clone(actual.Worker).(*composerpb.WorkloadsConfig_WorkerResource)
+	} else if desired.Worker != nil && actual.Worker != nil && desiredKRM != nil && desiredKRM.Worker != nil {
+		if desiredKRM.Worker.CPU == nil {
+			desired.Worker.Cpu = actual.Worker.Cpu
+		}
+		if desiredKRM.Worker.MemoryGB == nil {
+			desired.Worker.MemoryGb = actual.Worker.MemoryGb
+		}
+		if desiredKRM.Worker.StorageGB == nil {
+			desired.Worker.StorageGb = actual.Worker.StorageGb
+		}
+		if desiredKRM.Worker.MinCount == nil {
+			desired.Worker.MinCount = actual.Worker.MinCount
+		}
+		if desiredKRM.Worker.MaxCount == nil {
+			desired.Worker.MaxCount = actual.Worker.MaxCount
+		}
+	}
+
+	if desired.Triggerer == nil && actual.Triggerer != nil {
+		desired.Triggerer = proto.Clone(actual.Triggerer).(*composerpb.WorkloadsConfig_TriggererResource)
+	} else if desired.Triggerer != nil && actual.Triggerer != nil && desiredKRM != nil && desiredKRM.Triggerer != nil {
+		if desiredKRM.Triggerer.CPU == nil {
+			desired.Triggerer.Cpu = actual.Triggerer.Cpu
+		}
+		if desiredKRM.Triggerer.MemoryGB == nil {
+			desired.Triggerer.MemoryGb = actual.Triggerer.MemoryGb
+		}
+		if desiredKRM.Triggerer.Count == nil {
+			desired.Triggerer.Count = actual.Triggerer.Count
+		}
+	}
+
+	if desired.DagProcessor == nil && actual.DagProcessor != nil {
+		desired.DagProcessor = proto.Clone(actual.DagProcessor).(*composerpb.WorkloadsConfig_DagProcessorResource)
+	} else if desired.DagProcessor != nil && actual.DagProcessor != nil && desiredKRM != nil && desiredKRM.DagProcessor != nil {
+		if desiredKRM.DagProcessor.CPU == nil {
+			desired.DagProcessor.Cpu = actual.DagProcessor.Cpu
+		}
+		if desiredKRM.DagProcessor.MemoryGB == nil {
+			desired.DagProcessor.MemoryGb = actual.DagProcessor.MemoryGb
+		}
+		if desiredKRM.DagProcessor.StorageGB == nil {
+			desired.DagProcessor.StorageGb = actual.DagProcessor.StorageGb
+		}
+		if desiredKRM.DagProcessor.Count == nil {
+			desired.DagProcessor.Count = actual.DagProcessor.Count
+		}
+	}
+}
+
+func collapsePaths(paths sets.Set[string]) sets.Set[string] {
+	collapsed := sets.New[string]()
+	for path := range paths {
+		if strings.HasPrefix(path, "config.recovery_config.scheduled_snapshots_config.") {
+			collapsed.Insert("config.recovery_config.scheduled_snapshots_config")
+		} else {
+			collapsed.Insert(path)
+		}
+	}
+	return collapsed
 }

--- a/pkg/test/resourcefixture/testdata/basic/composer/v1beta1/composerenvironmentupdate/_generated_object_composerenvironmentupdate.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/composer/v1beta1/composerenvironmentupdate/_generated_object_composerenvironmentupdate.golden.yaml
@@ -1,0 +1,54 @@
+apiVersion: composer.cnrm.cloud.google.com/v1beta1
+kind: ComposerEnvironment
+metadata:
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 2
+  labels:
+    cnrm-test: "true"
+  name: composerenvironment-${uniqueId}
+  namespace: ${uniqueId}
+spec:
+  config:
+    environmentSize: ENVIRONMENT_SIZE_SMALL
+    recoveryConfig:
+      scheduledSnapshotsConfig:
+        enabled: true
+        snapshotCreationSchedule: 20 15 * * *
+        snapshotLocation: gs://bucket-${uniqueId}/snapshots
+        timeZone: UTC
+    workloadsConfig:
+      dagProcessor:
+        count: 1
+      scheduler:
+        count: 1
+      triggerer:
+        count: 2
+      worker:
+        maxCount: 3
+        minCount: 1
+  location: us-central1
+  projectRef:
+    external: ${projectId}
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  externalRef: projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}
+  observedGeneration: 2
+  observedState:
+    config:
+      airflowBYOIDURI: https://123456qwert-dot-us-central1.composer.byoid.googleusercontent.com
+      airflowURI: https://123456qwert-dot-us-central1.composer.googleusercontent.com
+      dagGCSPrefix: gs://us-central1-test-123456-asdfg-bucket/dags
+      gkeCluster: projects/${projectId}/locations/us-central1/clusters/us-central1-test-123456-asdfg-gke
+      privateEnvironmentConfig:
+        privateClusterConfig: {}
+    createTime: "1970-01-01T00:00:00Z"
+    state: RUNNING
+    updateTime: "1970-01-01T00:00:00Z"
+    uuid: test-uuid

--- a/pkg/test/resourcefixture/testdata/basic/composer/v1beta1/composerenvironmentupdate/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/composer/v1beta1/composerenvironmentupdate/_http.log
@@ -1,0 +1,945 @@
+GET https://storage.googleapis.com/storage/v1/b/bucket-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Pragma: no-cache
+Server: UploadServer
+Vary: Origin
+Vary: X-Origin
+
+{
+  "error": {
+    "code": 404,
+    "errors": [
+      {
+        "domain": "global",
+        "message": "The specified bucket does not exist.",
+        "reason": "notFound"
+      }
+    ],
+    "message": "The specified bucket does not exist."
+  }
+}
+
+---
+
+POST https://storage.googleapis.com/storage/v1/b?alt=json&prettyPrint=false&project=${projectId}
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+{
+  "iamConfiguration": {
+    "uniformBucketLevelAccess": {
+      "enabled": false
+    }
+  },
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lifecycle": {
+    "rule": []
+  },
+  "location": "us-central1",
+  "name": "bucket-${uniqueId}",
+  "storageClass": "STANDARD"
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Pragma: no-cache
+Server: UploadServer
+Vary: Origin
+Vary: X-Origin
+
+{
+  "etag": "abcdef0123A=",
+  "generation": "12345678901234",
+  "iamConfiguration": {
+    "bucketPolicyOnly": {
+      "enabled": false
+    },
+    "publicAccessPrevention": "inherited",
+    "uniformBucketLevelAccess": {
+      "enabled": false
+    }
+  },
+  "id": "000000000000000000000",
+  "kind": "storage#bucket",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "location": "US-CENTRAL1",
+  "locationType": "region",
+  "metageneration": "1",
+  "name": "bucket-${uniqueId}",
+  "projectNumber": "${projectNumber}",
+  "satisfiesPZI": true,
+  "selfLink": "https://www.googleapis.com/storage/v1/b/bucket-${uniqueId}",
+  "softDeletePolicy": {
+    "effectiveTime": "2024-04-01T12:34:56.123456Z",
+    "retentionDurationSeconds": "604800"
+  },
+  "storageClass": "STANDARD",
+  "timeCreated": "2024-04-01T12:34:56.123456Z",
+  "updated": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GET https://storage.googleapis.com/storage/v1/b/bucket-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: UploadServer
+Vary: Origin
+Vary: X-Origin
+
+{
+  "etag": "abcdef0123A=",
+  "generation": "12345678901234",
+  "iamConfiguration": {
+    "bucketPolicyOnly": {
+      "enabled": false
+    },
+    "publicAccessPrevention": "inherited",
+    "uniformBucketLevelAccess": {
+      "enabled": false
+    }
+  },
+  "id": "000000000000000000000",
+  "kind": "storage#bucket",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "location": "US-CENTRAL1",
+  "locationType": "region",
+  "metageneration": "1",
+  "name": "bucket-${uniqueId}",
+  "projectNumber": "${projectNumber}",
+  "satisfiesPZI": true,
+  "selfLink": "https://www.googleapis.com/storage/v1/b/bucket-${uniqueId}",
+  "softDeletePolicy": {
+    "effectiveTime": "2024-04-01T12:34:56.123456Z",
+    "retentionDurationSeconds": "604800"
+  },
+  "storageClass": "STANDARD",
+  "timeCreated": "2024-04-01T12:34:56.123456Z",
+  "updated": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GET https://composer.googleapis.com/v1/projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Fenvironments%2Fcomposerenvironment-${uniqueId}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "errors": [
+      {
+        "domain": "global",
+        "message": "environment \"projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}\" not found",
+        "reason": "notFound"
+      }
+    ],
+    "message": "environment \"projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}\" not found",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://composer.googleapis.com/v1/projects/${projectId}/locations/us-central1/environments?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1
+
+{
+  "config": {
+    "environmentSize": 1,
+    "workloadsConfig": {
+      "dagProcessor": {
+        "count": 1
+      },
+      "scheduler": {
+        "count": 1
+      },
+      "triggerer": {
+        "count": 1
+      },
+      "worker": {
+        "maxCount": 3,
+        "minCount": 1
+      }
+    }
+  },
+  "name": "projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}"
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.orchestration.airflow.service.v1.OperationMetadata",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "operationType": 1,
+    "resource": "projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}",
+    "resourceUuid": "test-uuid",
+    "state": 1
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
+}
+
+---
+
+GET https://composer.googleapis.com/v1/projects/${projectId}/locations/us-central1/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Foperations%2F${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.orchestration.airflow.service.v1.OperationMetadata",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "endTime": "2024-04-01T12:34:56.123456Z",
+    "operationType": "CREATE",
+    "resource": "projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}",
+    "resourceUuid": "test-uuid",
+    "state": "SUCCEEDED"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.orchestration.airflow.service.v1.Environment",
+    "config": {
+      "airflowByoidUri": "https://123456qwert-dot-us-central1.composer.byoid.googleusercontent.com",
+      "airflowUri": "https://123456qwert-dot-us-central1.composer.googleusercontent.com",
+      "dagGcsPrefix": "gs://us-central1-test-123456-asdfg-bucket/dags",
+      "dataRetentionConfig": {
+        "airflowMetadataRetentionConfig": {
+          "retentionMode": "RETENTION_MODE_DISABLED"
+        },
+        "taskLogsRetentionConfig": {
+          "storageMode": "CLOUD_LOGGING_ONLY"
+        }
+      },
+      "databaseConfig": {
+        "machineType": "db-custom-2-7680"
+      },
+      "encryptionConfig": {},
+      "environmentSize": "ENVIRONMENT_SIZE_SMALL",
+      "gkeCluster": "projects/${projectId}/locations/us-central1/clusters/us-central1-test-123456-asdfg-gke",
+      "maintenanceWindow": {
+        "endTime": "1970-01-01T04:00:00Z",
+        "recurrence": "FREQ=WEEKLY;BYDAY=FR,SA,SU",
+        "startTime": "1970-01-01T00:00:00Z"
+      },
+      "nodeConfig": {
+        "composerInternalIpv4CidrBlock": "172.31.251.0/24",
+        "composerNetworkAttachment": "projects/${projectId}/regions/us-central1/networkAttachments/test-attachment",
+        "ipAllocationPolicy": {
+          "useIpAliases": true
+        },
+        "network": "projects/${projectId}/global/networks/default",
+        "serviceAccount": "${projectNumber}-compute@developer.gserviceaccount.com"
+      },
+      "privateEnvironmentConfig": {
+        "cloudComposerNetworkIpv4CidrBlock": "172.31.245.0/24",
+        "cloudSqlIpv4CidrBlock": "10.0.0.0/12",
+        "privateClusterConfig": {}
+      },
+      "softwareConfig": {
+        "cloudDataLineageIntegration": {},
+        "imageVersion": "composer-2.11.3-airflow-2.10.2",
+        "pythonVersion": "3"
+      },
+      "webServerNetworkAccessControl": {
+        "allowedIpRanges": [
+          {
+            "description": "Allows access from all IPv4 addresses (default value)",
+            "value": "0.0.0.0/0"
+          },
+          {
+            "description": "Allows access from all IPv6 addresses (default value)",
+            "value": "::0/0"
+          }
+        ]
+      },
+      "workloadsConfig": {
+        "dagProcessor": {
+          "count": 1
+        },
+        "scheduler": {
+          "count": 1,
+          "cpu": 0.5,
+          "memoryGb": 2,
+          "storageGb": 1
+        },
+        "triggerer": {
+          "count": 1
+        },
+        "webServer": {
+          "cpu": 0.5,
+          "memoryGb": 2,
+          "storageGb": 1
+        },
+        "worker": {
+          "cpu": 0.5,
+          "maxCount": 3,
+          "memoryGb": 2,
+          "minCount": 1,
+          "storageGb": 1
+        }
+      }
+    },
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "name": "projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}",
+    "state": "RUNNING",
+    "storageConfig": {
+      "bucket": "us-central1-test-123456-asdfg-bucket"
+    },
+    "updateTime": "2024-04-01T12:34:56.123456Z",
+    "uuid": "test-uuid"
+  }
+}
+
+---
+
+GET https://composer.googleapis.com/v1/projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Fenvironments%2Fcomposerenvironment-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "config": {
+    "airflowByoidUri": "https://123456qwert-dot-us-central1.composer.byoid.googleusercontent.com",
+    "airflowUri": "https://123456qwert-dot-us-central1.composer.googleusercontent.com",
+    "dagGcsPrefix": "gs://us-central1-test-123456-asdfg-bucket/dags",
+    "dataRetentionConfig": {
+      "airflowMetadataRetentionConfig": {
+        "retentionMode": 2
+      },
+      "taskLogsRetentionConfig": {
+        "storageMode": 2
+      }
+    },
+    "databaseConfig": {},
+    "encryptionConfig": {},
+    "environmentSize": 1,
+    "gkeCluster": "projects/${projectId}/locations/us-central1/clusters/us-central1-test-123456-asdfg-gke",
+    "maintenanceWindow": {
+      "endTime": "1970-01-01T04:00:00Z",
+      "recurrence": "FREQ=WEEKLY;BYDAY=FR,SA,SU",
+      "startTime": "1970-01-01T00:00:00Z"
+    },
+    "nodeConfig": {
+      "composerInternalIpv4CidrBlock": "172.31.251.0/24",
+      "composerNetworkAttachment": "projects/${projectId}/regions/us-central1/networkAttachments/test-attachment",
+      "ipAllocationPolicy": {},
+      "network": "projects/${projectId}/global/networks/default",
+      "serviceAccount": "${projectNumber}-compute@developer.gserviceaccount.com"
+    },
+    "privateEnvironmentConfig": {
+      "cloudComposerNetworkIpv4CidrBlock": "172.31.245.0/24",
+      "cloudSqlIpv4CidrBlock": "10.0.0.0/12",
+      "privateClusterConfig": {}
+    },
+    "softwareConfig": {
+      "cloudDataLineageIntegration": {},
+      "imageVersion": "composer-2.11.3-airflow-2.10.2"
+    },
+    "webServerNetworkAccessControl": {
+      "allowedIpRanges": [
+        {
+          "description": "Allows access from all IPv4 addresses (default value)",
+          "value": "0.0.0.0/0"
+        },
+        {
+          "description": "Allows access from all IPv6 addresses (default value)",
+          "value": "::0/0"
+        }
+      ]
+    },
+    "workloadsConfig": {
+      "dagProcessor": {
+        "count": 1
+      },
+      "scheduler": {
+        "count": 1,
+        "cpu": 0.5,
+        "memoryGb": 2,
+        "storageGb": 1
+      },
+      "triggerer": {
+        "count": 1
+      },
+      "webServer": {
+        "cpu": 0.5,
+        "memoryGb": 2,
+        "storageGb": 1
+      },
+      "worker": {
+        "cpu": 0.5,
+        "maxCount": 3,
+        "memoryGb": 2,
+        "minCount": 1,
+        "storageGb": 1
+      }
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "name": "projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}",
+  "state": 2,
+  "storageConfig": {
+    "bucket": "us-central1-test-123456-asdfg-bucket"
+  },
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "uuid": "test-uuid"
+}
+
+---
+
+PATCH https://composer.googleapis.com/v1/projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}?%24alt=json%3Benum-encoding%3Dint&updateMask=config.recoveryConfig.scheduledSnapshotsConfig%2Cconfig.workloadsConfig.triggerer.count
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Fenvironments%2Fcomposerenvironment-${uniqueId}
+
+{
+  "config": {
+    "airflowByoidUri": "https://123456qwert-dot-us-central1.composer.byoid.googleusercontent.com",
+    "airflowUri": "https://123456qwert-dot-us-central1.composer.googleusercontent.com",
+    "dagGcsPrefix": "gs://us-central1-test-123456-asdfg-bucket/dags",
+    "dataRetentionConfig": {
+      "airflowMetadataRetentionConfig": {
+        "retentionMode": 2
+      },
+      "taskLogsRetentionConfig": {
+        "storageMode": 2
+      }
+    },
+    "environmentSize": 1,
+    "gkeCluster": "projects/${projectId}/locations/us-central1/clusters/us-central1-test-123456-asdfg-gke",
+    "maintenanceWindow": {
+      "endTime": "1970-01-01T04:00:00Z",
+      "recurrence": "FREQ=WEEKLY;BYDAY=FR,SA,SU",
+      "startTime": "1970-01-01T00:00:00Z"
+    },
+    "nodeConfig": {
+      "composerInternalIpv4CidrBlock": "172.31.251.0/24",
+      "composerNetworkAttachment": "projects/${projectId}/regions/us-central1/networkAttachments/test-attachment",
+      "ipAllocationPolicy": {},
+      "network": "projects/${projectId}/global/networks/default",
+      "serviceAccount": "${projectNumber}-compute@developer.gserviceaccount.com"
+    },
+    "privateEnvironmentConfig": {
+      "cloudComposerNetworkIpv4CidrBlock": "172.31.245.0/24",
+      "cloudSqlIpv4CidrBlock": "10.0.0.0/12",
+      "privateClusterConfig": {}
+    },
+    "recoveryConfig": {
+      "scheduledSnapshotsConfig": {
+        "enabled": true,
+        "snapshotCreationSchedule": "20 15 * * *",
+        "snapshotLocation": "gs://bucket-${uniqueId}/snapshots",
+        "timeZone": "UTC"
+      }
+    },
+    "softwareConfig": {
+      "cloudDataLineageIntegration": {},
+      "imageVersion": "composer-2.11.3-airflow-2.10.2"
+    },
+    "webServerNetworkAccessControl": {
+      "allowedIpRanges": [
+        {
+          "description": "Allows access from all IPv4 addresses (default value)",
+          "value": "0.0.0.0/0"
+        },
+        {
+          "description": "Allows access from all IPv6 addresses (default value)",
+          "value": "::0/0"
+        }
+      ]
+    },
+    "workloadsConfig": {
+      "dagProcessor": {
+        "count": 1
+      },
+      "scheduler": {
+        "count": 1,
+        "cpu": 0.5,
+        "memoryGb": 2,
+        "storageGb": 1
+      },
+      "triggerer": {
+        "count": 2
+      },
+      "webServer": {
+        "cpu": 0.5,
+        "memoryGb": 2,
+        "storageGb": 1
+      },
+      "worker": {
+        "cpu": 0.5,
+        "maxCount": 3,
+        "memoryGb": 2,
+        "minCount": 1,
+        "storageGb": 1
+      }
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "name": "projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}",
+  "state": 2,
+  "storageConfig": {
+    "bucket": "us-central1-test-123456-asdfg-bucket"
+  },
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "uuid": "test-uuid"
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.orchestration.airflow.service.v1.OperationMetadata",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "operationType": 3,
+    "resource": "projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}",
+    "resourceUuid": "test-uuid",
+    "state": 1
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
+}
+
+---
+
+GET https://composer.googleapis.com/v1/projects/${projectId}/locations/us-central1/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Foperations%2F${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.orchestration.airflow.service.v1.OperationMetadata",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "endTime": "2024-04-01T12:34:56.123456Z",
+    "operationType": "UPDATE",
+    "resource": "projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}",
+    "resourceUuid": "test-uuid",
+    "state": "SUCCEEDED"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.orchestration.airflow.service.v1.Environment",
+    "config": {
+      "airflowByoidUri": "https://123456qwert-dot-us-central1.composer.byoid.googleusercontent.com",
+      "airflowUri": "https://123456qwert-dot-us-central1.composer.googleusercontent.com",
+      "dagGcsPrefix": "gs://us-central1-test-123456-asdfg-bucket/dags",
+      "dataRetentionConfig": {
+        "airflowMetadataRetentionConfig": {
+          "retentionMode": "RETENTION_MODE_DISABLED"
+        },
+        "taskLogsRetentionConfig": {
+          "storageMode": "CLOUD_LOGGING_ONLY"
+        }
+      },
+      "databaseConfig": {
+        "machineType": "db-custom-2-7680"
+      },
+      "encryptionConfig": {},
+      "environmentSize": "ENVIRONMENT_SIZE_SMALL",
+      "gkeCluster": "projects/${projectId}/locations/us-central1/clusters/us-central1-test-123456-asdfg-gke",
+      "maintenanceWindow": {
+        "endTime": "1970-01-01T04:00:00Z",
+        "recurrence": "FREQ=WEEKLY;BYDAY=FR,SA,SU",
+        "startTime": "1970-01-01T00:00:00Z"
+      },
+      "nodeConfig": {
+        "composerInternalIpv4CidrBlock": "172.31.251.0/24",
+        "composerNetworkAttachment": "projects/${projectId}/regions/us-central1/networkAttachments/test-attachment",
+        "ipAllocationPolicy": {
+          "useIpAliases": true
+        },
+        "network": "projects/${projectId}/global/networks/default",
+        "serviceAccount": "${projectNumber}-compute@developer.gserviceaccount.com"
+      },
+      "privateEnvironmentConfig": {
+        "cloudComposerNetworkIpv4CidrBlock": "172.31.245.0/24",
+        "cloudSqlIpv4CidrBlock": "10.0.0.0/12",
+        "privateClusterConfig": {}
+      },
+      "recoveryConfig": {
+        "scheduledSnapshotsConfig": {
+          "enabled": true,
+          "snapshotCreationSchedule": "20 15 * * *",
+          "snapshotLocation": "gs://bucket-${uniqueId}/snapshots",
+          "timeZone": "UTC"
+        }
+      },
+      "softwareConfig": {
+        "cloudDataLineageIntegration": {},
+        "imageVersion": "composer-2.11.3-airflow-2.10.2",
+        "pythonVersion": "3"
+      },
+      "webServerNetworkAccessControl": {
+        "allowedIpRanges": [
+          {
+            "description": "Allows access from all IPv4 addresses (default value)",
+            "value": "0.0.0.0/0"
+          },
+          {
+            "description": "Allows access from all IPv6 addresses (default value)",
+            "value": "::0/0"
+          }
+        ]
+      },
+      "workloadsConfig": {
+        "dagProcessor": {
+          "count": 1
+        },
+        "scheduler": {
+          "count": 1,
+          "cpu": 0.5,
+          "memoryGb": 2,
+          "storageGb": 1
+        },
+        "triggerer": {
+          "count": 2
+        },
+        "webServer": {
+          "cpu": 0.5,
+          "memoryGb": 2,
+          "storageGb": 1
+        },
+        "worker": {
+          "cpu": 0.5,
+          "maxCount": 3,
+          "memoryGb": 2,
+          "minCount": 1,
+          "storageGb": 1
+        }
+      }
+    },
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "name": "projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}",
+    "state": "RUNNING",
+    "storageConfig": {
+      "bucket": "us-central1-test-123456-asdfg-bucket"
+    },
+    "updateTime": "2024-04-01T12:34:56.123456Z",
+    "uuid": "test-uuid"
+  }
+}
+
+---
+
+GET https://composer.googleapis.com/v1/projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Fenvironments%2Fcomposerenvironment-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "config": {
+    "airflowByoidUri": "https://123456qwert-dot-us-central1.composer.byoid.googleusercontent.com",
+    "airflowUri": "https://123456qwert-dot-us-central1.composer.googleusercontent.com",
+    "dagGcsPrefix": "gs://us-central1-test-123456-asdfg-bucket/dags",
+    "dataRetentionConfig": {
+      "airflowMetadataRetentionConfig": {
+        "retentionMode": 2
+      },
+      "taskLogsRetentionConfig": {
+        "storageMode": 2
+      }
+    },
+    "databaseConfig": {},
+    "encryptionConfig": {},
+    "environmentSize": 1,
+    "gkeCluster": "projects/${projectId}/locations/us-central1/clusters/us-central1-test-123456-asdfg-gke",
+    "maintenanceWindow": {
+      "endTime": "1970-01-01T04:00:00Z",
+      "recurrence": "FREQ=WEEKLY;BYDAY=FR,SA,SU",
+      "startTime": "1970-01-01T00:00:00Z"
+    },
+    "nodeConfig": {
+      "composerInternalIpv4CidrBlock": "172.31.251.0/24",
+      "composerNetworkAttachment": "projects/${projectId}/regions/us-central1/networkAttachments/test-attachment",
+      "ipAllocationPolicy": {},
+      "network": "projects/${projectId}/global/networks/default",
+      "serviceAccount": "${projectNumber}-compute@developer.gserviceaccount.com"
+    },
+    "privateEnvironmentConfig": {
+      "cloudComposerNetworkIpv4CidrBlock": "172.31.245.0/24",
+      "cloudSqlIpv4CidrBlock": "10.0.0.0/12",
+      "privateClusterConfig": {}
+    },
+    "recoveryConfig": {
+      "scheduledSnapshotsConfig": {
+        "enabled": true,
+        "snapshotCreationSchedule": "20 15 * * *",
+        "snapshotLocation": "gs://bucket-${uniqueId}/snapshots",
+        "timeZone": "UTC"
+      }
+    },
+    "softwareConfig": {
+      "cloudDataLineageIntegration": {},
+      "imageVersion": "composer-2.11.3-airflow-2.10.2"
+    },
+    "webServerNetworkAccessControl": {
+      "allowedIpRanges": [
+        {
+          "description": "Allows access from all IPv4 addresses (default value)",
+          "value": "0.0.0.0/0"
+        },
+        {
+          "description": "Allows access from all IPv6 addresses (default value)",
+          "value": "::0/0"
+        }
+      ]
+    },
+    "workloadsConfig": {
+      "dagProcessor": {
+        "count": 1
+      },
+      "scheduler": {
+        "count": 1,
+        "cpu": 0.5,
+        "memoryGb": 2,
+        "storageGb": 1
+      },
+      "triggerer": {
+        "count": 2
+      },
+      "webServer": {
+        "cpu": 0.5,
+        "memoryGb": 2,
+        "storageGb": 1
+      },
+      "worker": {
+        "cpu": 0.5,
+        "maxCount": 3,
+        "memoryGb": 2,
+        "minCount": 1,
+        "storageGb": 1
+      }
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "name": "projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}",
+  "state": 2,
+  "storageConfig": {
+    "bucket": "us-central1-test-123456-asdfg-bucket"
+  },
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "uuid": "test-uuid"
+}
+
+---
+
+DELETE https://composer.googleapis.com/v1/projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Fenvironments%2Fcomposerenvironment-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.orchestration.airflow.service.v1.OperationMetadata",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "operationType": 2,
+    "resource": "projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}",
+    "state": 1
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
+}
+
+---
+
+GET https://composer.googleapis.com/v1/projects/${projectId}/locations/us-central1/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Foperations%2F${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.orchestration.airflow.service.v1.OperationMetadata",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "endTime": "2024-04-01T12:34:56.123456Z",
+    "operationType": "DELETE",
+    "resource": "projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}",
+    "state": "SUCCEEDED"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.protobuf.Empty"
+  }
+}
+
+---
+
+GET https://storage.googleapis.com/storage/v1/b/bucket-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: UploadServer
+Vary: Origin
+Vary: X-Origin
+
+{
+  "etag": "abcdef0123A=",
+  "generation": "12345678901234",
+  "iamConfiguration": {
+    "bucketPolicyOnly": {
+      "enabled": false
+    },
+    "publicAccessPrevention": "inherited",
+    "uniformBucketLevelAccess": {
+      "enabled": false
+    }
+  },
+  "id": "000000000000000000000",
+  "kind": "storage#bucket",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "location": "US-CENTRAL1",
+  "locationType": "region",
+  "metageneration": "1",
+  "name": "bucket-${uniqueId}",
+  "projectNumber": "${projectNumber}",
+  "satisfiesPZI": true,
+  "selfLink": "https://www.googleapis.com/storage/v1/b/bucket-${uniqueId}",
+  "softDeletePolicy": {
+    "effectiveTime": "2024-04-01T12:34:56.123456Z",
+    "retentionDurationSeconds": "604800"
+  },
+  "storageClass": "STANDARD",
+  "timeCreated": "2024-04-01T12:34:56.123456Z",
+  "updated": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GET https://storage.googleapis.com/storage/v1/b/bucket-${uniqueId}/o?alt=json&prettyPrint=false&versions=true
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: UploadServer
+Vary: Origin
+Vary: X-Origin
+
+{
+  "kind": "storage#objects",
+  "prefixes": [
+    "testfolder",
+    "testmanagedfolder"
+  ]
+}
+
+---
+
+DELETE https://storage.googleapis.com/storage/v1/b/bucket-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+204 No Content
+Content-Type: application/json
+Pragma: no-cache
+Server: UploadServer
+Vary: Origin
+Vary: X-Origin

--- a/pkg/test/resourcefixture/testdata/basic/composer/v1beta1/composerenvironmentupdate/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/composer/v1beta1/composerenvironmentupdate/create.yaml
@@ -1,0 +1,34 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: composer.cnrm.cloud.google.com/v1beta1
+kind: ComposerEnvironment
+metadata:
+  name: composerenvironment-${uniqueId}
+spec:
+  location: us-central1
+  projectRef:
+    external: ${projectId}
+  config:
+    environmentSize: ENVIRONMENT_SIZE_SMALL
+    workloadsConfig:
+      dagProcessor:
+        count: 1
+      scheduler:
+        count: 1
+      triggerer:
+        count: 1
+      worker:
+        minCount: 1
+        maxCount: 3

--- a/pkg/test/resourcefixture/testdata/basic/composer/v1beta1/composerenvironmentupdate/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/composer/v1beta1/composerenvironmentupdate/dependencies.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: storage.cnrm.cloud.google.com/v1beta1
+kind: StorageBucket
+metadata:
+  name: bucket-${uniqueId}
+spec:
+  location: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/composer/v1beta1/composerenvironmentupdate/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/composer/v1beta1/composerenvironmentupdate/update.yaml
@@ -1,0 +1,40 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: composer.cnrm.cloud.google.com/v1beta1
+kind: ComposerEnvironment
+metadata:
+  name: composerenvironment-${uniqueId}
+spec:
+  location: us-central1
+  projectRef:
+    external: ${projectId}
+  config:
+    environmentSize: ENVIRONMENT_SIZE_SMALL
+    workloadsConfig:
+      dagProcessor:
+        count: 1
+      scheduler:
+        count: 1
+      triggerer:
+        count: 2 # Updated from 1
+      worker:
+        minCount: 1
+        maxCount: 3
+    recoveryConfig:
+      scheduledSnapshotsConfig:
+        enabled: true
+        snapshotCreationSchedule: "20 15 * * *"
+        snapshotLocation: gs://bucket-${uniqueId}/snapshots
+        timeZone: "UTC"


### PR DESCRIPTION
Fixes b/543582925

- Collapse scheduled snapshots config paths in update mask to parent path to satisfy Composer API validation (avoids 400 bad request).
- Implement KRM-guided defaulting for workloads config to prevent drift detection on unspecified fields (avoids 400 no-change request).
- Update mock GCP to support these update paths.
- Add e2e test fixture to verify.
