### PR TITLE
tests/apichecks: make missingrefs.txt a fail-closed ratchet

### DIFF
--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -21,10 +21,12 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 )
@@ -86,6 +88,75 @@ func extractEventsWithURLPrefix(allEvents, urlPrefix string) string {
 		}
 	}
 	return strings.Join(eventStrings, "---")
+}
+
+// CompareRatchetFile compares got against a baseline "known violations" file using
+// ratchet semantics, for checks where the baseline records violations we tolerate but
+// never want more of.
+//
+// It differs from CompareGoldenFile in one critical way: NEW entries always fail the
+// test, including when WRITE_GOLDEN_OUTPUT is set. A golden file silently absorbs new
+// violations during the normal regenerate-goldens workflow, which turns the check into
+// a no-op for exactly the changes it exists to catch.
+//
+// Entries that disappear (violations that were fixed) are pruned from the file when
+// WRITE_GOLDEN_OUTPUT is set, so the baseline can only ever shrink.
+func CompareRatchetFile(t *testing.T, p, fullGot string) {
+	t.Helper()
+
+	writeOutput := os.Getenv("WRITE_GOLDEN_OUTPUT") != ""
+
+	splitLines := func(s string) []string {
+		var out []string
+		for _, line := range strings.Split(s, "\n") {
+			if line = strings.TrimSpace(line); line != "" {
+				out = append(out, line)
+			}
+		}
+		return out
+	}
+
+	wantBytes, err := os.ReadFile(p)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			t.Fatalf("FAIL: failed to read ratchet file %q: %v", p, err)
+		}
+		// No baseline file: only acceptable if there is nothing to record.
+		if strings.TrimSpace(fullGot) == "" {
+			return
+		}
+		t.Fatalf("FAIL: ratchet file %q does not exist but violations were found. "+
+			"Create the baseline deliberately; it is not generated automatically.", p)
+	}
+
+	baseline := sets.NewString(splitLines(string(wantBytes))...)
+	got := sets.NewString(splitLines(fullGot)...)
+
+	added := got.Difference(baseline).List()
+	removed := baseline.Difference(got).List()
+
+	if len(added) > 0 {
+		sort.Strings(added)
+		t.Errorf("FAIL: %d new violation(s) not present in %s.\n\n%s\n\n"+
+			"Fix these rather than adding them to the exceptions file. "+
+			"This check does not accept new entries, even with WRITE_GOLDEN_OUTPUT set.",
+			len(added), p, strings.Join(added, "\n"))
+		// Deliberately do not write: writing here is what lets violations slip in.
+		return
+	}
+
+	if len(removed) > 0 {
+		if writeOutput {
+			// No trailing newline: matches how these baselines are written today
+			// (strings.Join of the violation list), so pruning produces a minimal diff.
+			if err := os.WriteFile(p, []byte(strings.Join(got.List(), "\n")), 0644); err != nil {
+				t.Fatalf("FAIL: failed to write ratchet file %s: %v", p, err)
+			}
+			t.Logf("pruned %d fixed violation(s) from %s", len(removed), p)
+		} else {
+			t.Logf("%d violation(s) in %s appear to be fixed; rerun with WRITE_GOLDEN_OUTPUT=1 to prune them", len(removed), p)
+		}
+	}
 }
 
 // CompareGoldenFile performs a file comparison for a golden test.

--- a/tests/apichecks/crds_test.go
+++ b/tests/apichecks/crds_test.go
@@ -143,7 +143,7 @@ func TestMissingRefs(t *testing.T) {
 
 	want := strings.Join(errs, "\n")
 
-	test.CompareGoldenFile(t, "testdata/exceptions/missingrefs.txt", want)
+	test.CompareRatchetFile(t, "testdata/exceptions/missingrefs.txt", want)
 }
 
 // Looks for fields that looks like refs, but are in the status.


### PR DESCRIPTION
### BRIEF Change description

Makes `tests/apichecks/testdata/exceptions/missingrefs.txt` a **fail-closed ratchet**: new
violations fail the test and are never written to the file, while fixed violations are pruned.
The baseline can only shrink.

Part of #12344. **No baseline change** — `missingrefs.txt` is byte-identical to master.

#### WHY do we need this change?

`missingrefs.txt` is not an allowlist. It is a snapshot of every ref-like field currently in the
tree, compared via `CompareGoldenFile` — which **overwrites the golden file** whenever
`WRITE_GOLDEN_OUTPUT` is set.

So the normal "run the presubmit, regenerate goldens, commit the result" loop promotes newly
detected violations into the accepted-exceptions list. The first run fails; the second passes.
A correct finding is silently reclassified as an accepted exception, leaving only a few extra
lines in a large diff as evidence.

That is the mechanism behind the review feedback on #11964 (*"Do no make new additions to this
file. Every field here need to be implemented as a KCC ref field!"*). It does not scale to batch
generation: on one resource `+1` line in an exceptions file is conspicuous; across eighteen it
is not.

`CompareRatchetFile` inverts both behaviours:

- new entries **fail**, including under `WRITE_GOLDEN_OUTPUT`, and the file is **not written**
  when additions are present
- entries that disappear are pruned under `WRITE_GOLDEN_OUTPUT`, so the baseline can only shrink

#### Special notes for your reviewer:

This PR deliberately contains **only** the guardrail. `missingrefs.txt` is unchanged, and the
existing 102 entries remain tolerated — this only stops the file growing.

A follow-up PR improves the detector itself (it currently cannot see Cloud Storage or BigQuery
URIs). That one does grow the baseline, for reasons argued there; keeping the two separate so
this mechanism can be reviewed on its own.

Worth considering later: the same treatment for `acronyms.txt`, `naming_violations.txt` and
`spec_dislike_etag.txt`, which drew similar review comments on #11964.

#### Does this PR add something which needs to be 'release noted'?

```release-note
NONE
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

```docs

```

#### Intended Milestone

- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

Ran `dev/tasks/validate-and-push`, which runs `make fmt`, `go vet ./...`,
`dev/ci/presubmits/validate-generated-files` and `dev/ci/presubmits/unit-tests`. All passed with
a clean working tree.

Verified the baseline is untouched:

```
$ git diff master -- tests/apichecks/testdata/exceptions/missingrefs.txt
(empty)
$ go test ./tests/apichecks/ -run TestMissingRefs -count=1
ok
```

End-to-end proof of the ratchet — deleted a baseline line to simulate a new violation, then ran
the exact path that failed in #11964:

```
$ WRITE_GOLDEN_OUTPUT=1 go test ./tests/apichecks/ -run TestMissingRefs -count=1
--- FAIL: TestMissingRefs
    crds_test.go:146: FAIL: 1 new violation(s) not present in testdata/exceptions/missingrefs.txt.
        [refs] crd=alloydbbackups... field ".spec.encryptionConfig.kmsKeyName" should be a reference
        Fix these rather than adding them to the exceptions file. This check does not accept
        new entries, even with WRITE_GOLDEN_OUTPUT set.
```

The file was **not** rewritten. The prune direction was also verified: adding a stale entry passes
with an advisory, and `WRITE_GOLDEN_OUTPUT=1` removes it, restoring the file byte-for-byte.

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
