### PR TITLE
Initialize buildx container builder driver in dev/tasks/build-images

### DIFF
--- a/dev/tasks/build-images
+++ b/dev/tasks/build-images
@@ -51,6 +51,10 @@ export CONFIG_CONNECTOR_IMG=${IMAGE_PREFIX}config-connector-cli:${IMAGE_TAG}
 export OPERATOR_IMG=${IMAGE_PREFIX}operator:${IMAGE_TAG}
 
 cd ${REPO_ROOT}
+
+# Create and switch to a container-based buildx builder if not already active
+docker buildx create --name container-builder --driver docker-container --use 2>/dev/null || docker buildx use container-builder 2>/dev/null || true
+
 echo "===> [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Starting core image builds (docker buildx bake)..."
 IMAGE_PREFIX="${IMAGE_PREFIX}" IMAGE_TAG="${IMAGE_TAG}" docker buildx bake --load --set *.cache-from=type=gha,scope=kcc --set *.cache-to=type=gha,mode=max,scope=kcc
 echo "===> [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Completed core image builds."


### PR DESCRIPTION
### BRIEF Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Updates [`dev/tasks/build-images`](file:///usr/local/google/home/maqiuyu/go/src/github.com/maqiuyujoyce/k8s-config-connector/dev/tasks/build-images) to initialize and switch to a `docker-container` BuildKit builder instance (`docker buildx create --name container-builder --driver docker-container --use`) before invoking `docker buildx bake`.

In Louhi and Google Cloud Build runners (e.g., `gcr.io/cloud-builders/docker`), `docker buildx` defaults to the host daemon's built-in `docker` driver with the legacy `dockerfile.v0` parser.
Because [`docker-bake.hcl`](file:///usr/local/google/home/maqiuyu/go/src/github.com/maqiuyujoyce/k8s-config-connector/docker-bake.hcl) defines inter-target context dependencies (`contexts = { "builder:${IMAGE_TAG}" = "target:builder" }`), the legacy parser fails with:
```text
ERROR: target config-connector: failed to solve: rpc error: code = Unknown desc = failed to solve with frontend dockerfile.v0: unsupported frontend capability moby.buildkit.frontend.contexts
```

To fix this issue, we should create and activate a dedicated BuildKit container instance (`docker-container` driver) before running `docker buildx bake`. The upstream BuildKit container supports `moby.buildkit.frontend.contexts` natively, while the `--load` flag ensures built images are exported back into the local Docker daemon for subsequent pipeline steps and registry pushes.

#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
