### PR TITLE
fix(run): preserve custom audiences in Terraform state

### DIFF
--- a/pkg/controller/tf/cloudrunv2_custom_audiences_test.go
+++ b/pkg/controller/tf/cloudrunv2_custom_audiences_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tf_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	cloudrunv2 "github.com/hashicorp/terraform-provider-google-beta/google-beta/services/cloudrunv2"
+	transport_tpg "github.com/hashicorp/terraform-provider-google-beta/google-beta/transport"
+)
+
+func TestCloudRunV2ServiceReadPersistsCustomAudiences(t *testing.T) {
+	wantAudiences := []string{
+		"https://service.example.com",
+		"https://service.example.net",
+		"https://service.example.org",
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q, want GET", r.Method)
+			http.Error(w, "unexpected method", http.StatusBadRequest)
+			return
+		}
+		if r.URL.Path != "/v2/projects/test-project/locations/us-central1/services/test-service" {
+			t.Errorf("path = %q", r.URL.Path)
+			http.Error(w, "unexpected path", http.StatusBadRequest)
+			return
+		}
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"name":            "projects/test-project/locations/us-central1/services/test-service",
+			"customAudiences": wantAudiences,
+		}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	resource := cloudrunv2.ResourceCloudRunV2Service()
+	resourceData := schema.TestResourceDataRaw(t, resource.Schema, map[string]any{
+		"name":     "test-service",
+		"project":  "test-project",
+		"location": "us-central1",
+	})
+	resourceData.SetId("projects/test-project/locations/us-central1/services/test-service")
+	config := &transport_tpg.Config{
+		Project:            "test-project",
+		CloudRunV2BasePath: server.URL + "/v2/",
+		Client:             server.Client(),
+	}
+
+	if err := resource.Read(resourceData, config); err != nil {
+		t.Fatalf("read Cloud Run service: %v", err)
+	}
+
+	gotRaw := resourceData.Get("custom_audiences").([]interface{})
+	gotAudiences := make([]string, len(gotRaw))
+	for i, audience := range gotRaw {
+		gotAudiences[i] = audience.(string)
+	}
+	if diff := cmp.Diff(wantAudiences, gotAudiences); diff != "" {
+		t.Fatalf("custom_audiences mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/cloudrunv2/resource_cloud_run_v2_service.go
+++ b/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/cloudrunv2/resource_cloud_run_v2_service.go
@@ -1274,7 +1274,7 @@ func resourceCloudRunV2ServiceRead(d *schema.ResourceData, meta interface{}) err
 	if err := d.Set("binary_authorization", flattenCloudRunV2ServiceBinaryAuthorization(res["binaryAuthorization"], d, config)); err != nil {
 		return fmt.Errorf("Error reading Service: %s", err)
 	}
-	if err := d.Set("custom_audiences", flattenCloudRunV2ServiceCustomAudiences(res["custom_audiences"], d, config)); err != nil {
+	if err := d.Set("custom_audiences", flattenCloudRunV2ServiceCustomAudiences(res["customAudiences"], d, config)); err != nil {
 		return fmt.Errorf("Error reading Service: %s", err)
 	}
 	if err := d.Set("template", flattenCloudRunV2ServiceTemplate(res["template"], d, config)); err != nil {


### PR DESCRIPTION
## Why

Config Connector's vendored Cloud Run v2 Terraform provider reads `custom_audiences` from the wrong response key. Cloud Run returns `customAudiences`, so Terraform drops configured audiences from state, reports a perpetual diff, and Config Connector sends periodic no-op `UpdateService` calls.

## Before / after

```text
Cloud Run v2 GET --> customAudiences

Before: provider reads custom_audiences --> empty Terraform state
        --> persistent diff --> no-op UpdateService

After:  provider reads customAudiences --> state matches config
        --> empty diff --> no UpdateService
```

- Read the Cloud Run v2 API response using the correct camel-case key.
- Add a regression test that serves a mocked v2 response and verifies the provider stores all custom audiences.

## Notes

The upstream Terraform provider already uses the camel-case response key. This backports that mapping to Config Connector's vendored provider snapshot.

## Proof

- `go test ./pkg/controller/tf -run '^TestCloudRunV2ServiceReadPersistsCustomAudiences$' -count=1 -v`
- `go test ./pkg/controller/tf -count=1`
- `go vet ./pkg/controller/tf`
- `make vet`
- Read-only live KCC preview against `application-controller/app-default-a-lilac-bison-6vaneo` after the patch:

  ```text
  live preview found no Terraform diff and attempted no Cloud Run write
  PASS
  ```

No Apps Platform or Cloud Run resources were mutated during verification.
