### PR TITLE
ComposerEnvironment: Ensure the resource status is RUNNING before updating

### DIFF
--- a/pkg/controller/direct/composer/composerenvironment_controller.go
+++ b/pkg/controller/direct/composer/composerenvironment_controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/common/parent"
 	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/composer/v1beta1"
 	refs "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/common"
@@ -36,6 +37,7 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
@@ -176,6 +178,23 @@ func (a *EnvironmentAdapter) Update(ctx context.Context, updateOp *directbase.Up
 	log := klog.FromContext(ctx)
 	log.V(2).Info("updating Environment", "name", a.id)
 	mapCtx := &direct.MapContext{}
+
+	if a.actual != nil && a.actual.State != composerpb.Environment_RUNNING {
+		log.V(2).Info("Environment is not in RUNNING state, skipping update and requesting requeue", "name", a.id, "state", a.actual.State)
+		status := &krm.ComposerEnvironmentStatus{}
+		status.ObservedState = ComposerEnvironmentObservedState_FromProto(mapCtx, a.actual)
+		if mapCtx.Err() != nil {
+			return mapCtx.Err()
+		}
+		readyCondition := &v1alpha1.Condition{
+			Type:    v1alpha1.ReadyConditionType,
+			Status:  v1.ConditionFalse,
+			Reason:  "Updating",
+			Message: fmt.Sprintf("Environment is in state %s", a.actual.State),
+		}
+		updateOp.RequestRequeue()
+		return updateOp.UpdateStatus(ctx, status, readyCondition)
+	}
 
 	desired := a.desired.DeepCopy()
 	if err := ResolveEnvironmentRefs(ctx, a.k8sClient, desired); err != nil {

--- a/pkg/controller/direct/composer/composerenvironment_controller.go
+++ b/pkg/controller/direct/composer/composerenvironment_controller.go
@@ -32,6 +32,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/common"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/mappers"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/structuredreporting"
 	"google.golang.org/api/option"
@@ -180,19 +181,39 @@ func (a *EnvironmentAdapter) Update(ctx context.Context, updateOp *directbase.Up
 	mapCtx := &direct.MapContext{}
 
 	if a.actual != nil && a.actual.State != composerpb.Environment_RUNNING {
-		log.V(2).Info("Environment is not in RUNNING state, skipping update and requesting requeue", "name", a.id, "state", a.actual.State)
 		status := &krm.ComposerEnvironmentStatus{}
 		status.ObservedState = ComposerEnvironmentObservedState_FromProto(mapCtx, a.actual)
 		if mapCtx.Err() != nil {
 			return mapCtx.Err()
 		}
-		readyCondition := &v1alpha1.Condition{
-			Type:    v1alpha1.ReadyConditionType,
-			Status:  v1.ConditionFalse,
-			Reason:  "Updating",
-			Message: fmt.Sprintf("Environment is in state %s", a.actual.State),
+		var readyCondition *v1alpha1.Condition
+		switch a.actual.State {
+		case composerpb.Environment_ERROR:
+			log.V(2).Info("Environment is in terminal state, skipping update without requeue", "name", a.id, "state", a.actual.State)
+			readyCondition = &v1alpha1.Condition{
+				Type:    v1alpha1.ReadyConditionType,
+				Status:  v1.ConditionFalse,
+				Reason:  k8s.UpToDate,
+				Message: fmt.Sprintf("Environment is in error(current state: %s), update is not applied", a.actual.State),
+			}
+		case composerpb.Environment_DELETING:
+			log.V(2).Info("Environment is being deleted, skipping update without requeue", "name", a.id, "state", a.actual.State)
+			readyCondition = &v1alpha1.Condition{
+				Type:    v1alpha1.ReadyConditionType,
+				Status:  v1.ConditionFalse,
+				Reason:  k8s.Updating,
+				Message: fmt.Sprintf("Environment is deing deleted(current state: %s), update is not applied", a.actual.State),
+			}
+		default:
+			log.V(2).Info("Environment is in transient state, skipping update and requesting requeue", "name", a.id, "state", a.actual.State)
+			readyCondition = &v1alpha1.Condition{
+				Type:    v1alpha1.ReadyConditionType,
+				Status:  v1.ConditionFalse,
+				Reason:  k8s.Updating,
+				Message: fmt.Sprintf("Waiting for Environment to transition to RUNNING state before applying updates (current state: %s)", a.actual.State),
+			}
+			updateOp.RequestRequeue()
 		}
-		updateOp.RequestRequeue()
 		return updateOp.UpdateStatus(ctx, status, readyCondition)
 	}
 

--- a/pkg/controller/direct/composer/composerenvironment_controller.go
+++ b/pkg/controller/direct/composer/composerenvironment_controller.go
@@ -186,33 +186,25 @@ func (a *EnvironmentAdapter) Update(ctx context.Context, updateOp *directbase.Up
 		if mapCtx.Err() != nil {
 			return mapCtx.Err()
 		}
-		var readyCondition *v1alpha1.Condition
+		var logMsg, condMsg string
 		switch a.actual.State {
 		case composerpb.Environment_ERROR:
-			log.V(2).Info("Environment is in terminal state, skipping update without requeue", "name", a.id, "state", a.actual.State)
-			readyCondition = &v1alpha1.Condition{
-				Type:    v1alpha1.ReadyConditionType,
-				Status:  v1.ConditionFalse,
-				Reason:  k8s.UpToDate,
-				Message: fmt.Sprintf("Environment is in error(current state: %s), update is not applied", a.actual.State),
-			}
+			logMsg = "Environment is in error state, skipping update without requeue"
+			condMsg = fmt.Sprintf("Environment is in error (current state: %s), update is not applied", a.actual.State)
 		case composerpb.Environment_DELETING:
-			log.V(2).Info("Environment is being deleted, skipping update without requeue", "name", a.id, "state", a.actual.State)
-			readyCondition = &v1alpha1.Condition{
-				Type:    v1alpha1.ReadyConditionType,
-				Status:  v1.ConditionFalse,
-				Reason:  k8s.Updating,
-				Message: fmt.Sprintf("Environment is deing deleted(current state: %s), update is not applied", a.actual.State),
-			}
+			logMsg = "Environment is being deleted, skipping update without requeue"
+			condMsg = fmt.Sprintf("Environment is being deleted (current state: %s), update is not applied", a.actual.State)
 		default:
-			log.V(2).Info("Environment is in transient state, skipping update and requesting requeue", "name", a.id, "state", a.actual.State)
-			readyCondition = &v1alpha1.Condition{
-				Type:    v1alpha1.ReadyConditionType,
-				Status:  v1.ConditionFalse,
-				Reason:  k8s.Updating,
-				Message: fmt.Sprintf("Waiting for Environment to transition to RUNNING state before applying updates (current state: %s)", a.actual.State),
-			}
+			logMsg = "Environment is in transient state, skipping update and requesting requeue"
+			condMsg = fmt.Sprintf("Waiting for Environment to transition to RUNNING state before applying updates (current state: %s)", a.actual.State)
 			updateOp.RequestRequeue()
+		}
+		log.V(2).Info(logMsg, "name", a.id, "state", a.actual.State)
+		readyCondition := &v1alpha1.Condition{
+			Type:    v1alpha1.ReadyConditionType,
+			Status:  v1.ConditionFalse,
+			Reason:  k8s.Updating,
+			Message: condMsg,
 		}
 		return updateOp.UpdateStatus(ctx, status, readyCondition)
 	}


### PR DESCRIPTION
### BRIEF Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Updating a ComposerEnvironment takes approximately 10 minutes to complete. While the resource status remains UPDATING, modifications are not reflected in the actual state. The diff between the desired and actual states triggers repeated Update API calls until the environment transitions to RUNNING and the changes are successfully applied. 

Skip the update of a ComposerEnvironment when the state of the underlying GCP Composer environment is not RUNNING / is UPDATING, to avoid overload the API when it's still working on the environment.

#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Bug fix
ComposerEnvironment: Skip the update of a ComposerEnvironment when the state of the underlying GCP Composer environment is not RUNNING.
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
