### PR TITLE
fix(bigquerydataset): correct FullID and selfLink conversion for project IDs containing a colon

### DIFF
--- a/pkg/controller/direct/bigquerydataset/bigquerydataset_controller.go
+++ b/pkg/controller/direct/bigquerydataset/bigquerydataset_controller.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"strings"
 
 	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/bigquery/v1beta1"
 	refs "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
@@ -180,14 +179,12 @@ func (a *Adapter) Create(ctx context.Context, createOp *directbase.CreateOperati
 		return err
 	}
 	// Write resourceID into spec.
-	tokens := strings.Split(createdMetadata.FullID, ":")
-	if len(tokens) == 2 {
-		resourceID := tokens[1]
-		if err := unstructured.SetNestedField(createOp.GetUnstructured().Object, resourceID, "spec", "resourceID"); err != nil {
-			return fmt.Errorf("error setting spec.resourceID: %w", err)
-		}
-	} else {
+	_, resourceID, ok := parseDatasetFullID(createdMetadata.FullID)
+	if !ok {
 		return fmt.Errorf("Error getting resourceID: %s. The full ID of the created BigQueryDataset is expected to be in the format of projectID:datasetID", createdMetadata.FullID)
+	}
+	if err := unstructured.SetNestedField(createOp.GetUnstructured().Object, resourceID, "spec", "resourceID"); err != nil {
+		return fmt.Errorf("error setting spec.resourceID: %w", err)
 	}
 
 	return nil

--- a/pkg/controller/direct/bigquerydataset/bigquerydataset_mappings.go
+++ b/pkg/controller/direct/bigquerydataset/bigquerydataset_mappings.go
@@ -111,7 +111,7 @@ func BigQueryDatasetStatus_ToProto(mapCtx *direct.MapContext, in *krm.BigQueryDa
 	out.LastModifiedTime = direct.UnixMillisToTime(direct.ValueOf(in.LastModifiedTime))
 	// The full dataset ID in the form projectID:datasetID
 	if in.SelfLink != nil {
-		selfLink := strings.Trim(direct.ValueOf(in.SelfLink), "https://bigquery.googleapis.com/bigquery/v2/")
+		selfLink := strings.TrimPrefix(direct.ValueOf(in.SelfLink), "https://bigquery.googleapis.com/bigquery/v2/")
 		tokens := strings.Split(selfLink, "/")
 		if len(tokens) == 4 && tokens[0] == "projects" && tokens[2] == "datasets" {
 			out.FullID = fmt.Sprintf("%s:%s", tokens[1], tokens[3])

--- a/pkg/controller/direct/bigquerydataset/bigquerydataset_mappings.go
+++ b/pkg/controller/direct/bigquerydataset/bigquerydataset_mappings.go
@@ -81,9 +81,8 @@ func BigQueryDatasetSpec_FromProto(mapCtx *direct.MapContext, in *pb.DatasetMeta
 	out.MaxTimeTravelHours = direct.LazyPtr(maxTimeInHours)
 	out.IsCaseInsensitive = direct.LazyPtr(in.IsCaseInsensitive)
 	out.StorageBillingModel = direct.LazyPtr(in.StorageBillingModel)
-	tokens := strings.Split(in.FullID, ":")
-	if len(tokens) == 2 {
-		out.ResourceID = direct.LazyPtr(tokens[1])
+	if _, datasetID, ok := parseDatasetFullID(in.FullID); ok {
+		out.ResourceID = direct.LazyPtr(datasetID)
 	}
 	return out
 }
@@ -96,9 +95,8 @@ func BigQueryDatasetStatus_FromProto(mapCtx *direct.MapContext, in *pb.DatasetMe
 	out.CreationTime = direct.LazyPtr(in.CreationTime.UnixMilli())
 	out.LastModifiedTime = direct.LazyPtr(in.LastModifiedTime.UnixMilli())
 	// The full dataset ID in the form projectID:datasetID
-	tokens := strings.Split(in.FullID, ":")
-	if len(tokens) == 2 {
-		out.SelfLink = direct.LazyPtr(fmt.Sprintf("https://bigquery.googleapis.com/bigquery/v2/projects/%s/datasets/%s", tokens[0], tokens[1]))
+	if projectID, datasetID, ok := parseDatasetFullID(in.FullID); ok {
+		out.SelfLink = direct.LazyPtr(fmt.Sprintf("https://bigquery.googleapis.com/bigquery/v2/projects/%s/datasets/%s", projectID, datasetID))
 	}
 	out.ObservedState = &krm.BigQueryDatasetObservedState{Location: direct.LazyPtr(in.Location)}
 	return out

--- a/pkg/controller/direct/bigquerydataset/bigquerydataset_mappings_test.go
+++ b/pkg/controller/direct/bigquerydataset/bigquerydataset_mappings_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigquerydataset
+
+import (
+	"testing"
+
+	pb "cloud.google.com/go/bigquery"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
+)
+
+// TestBigQueryDatasetStatus_FromProto_selfLink checks the self-link built from
+// FullID, which is where a project ID containing a colon previously caused the
+// link to be dropped entirely.
+func TestBigQueryDatasetStatus_FromProto_selfLink(t *testing.T) {
+	tests := []struct {
+		name     string
+		fullID   string
+		expected string
+	}{
+		{
+			name:     "plainProjectID",
+			fullID:   "my-project:my_dataset",
+			expected: "https://bigquery.googleapis.com/bigquery/v2/projects/my-project/datasets/my_dataset",
+		},
+		{
+			name:     "universeQualifiedProjectID",
+			fullID:   "my-universe:my-project:my_dataset",
+			expected: "https://bigquery.googleapis.com/bigquery/v2/projects/my-universe:my-project/datasets/my_dataset",
+		},
+		{
+			name:     "domainScopedProjectID",
+			fullID:   "example.com:my-project:my_dataset",
+			expected: "https://bigquery.googleapis.com/bigquery/v2/projects/example.com:my-project/datasets/my_dataset",
+		},
+		{
+			name:     "malformedFullID_noSelfLink",
+			fullID:   "my_dataset",
+			expected: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mapCtx := &direct.MapContext{}
+			status := BigQueryDatasetStatus_FromProto(mapCtx, &pb.DatasetMetadata{FullID: tc.fullID})
+			if err := mapCtx.Err(); err != nil {
+				t.Fatalf("BigQueryDatasetStatus_FromProto returned error: %v", err)
+			}
+
+			got := ""
+			if status.SelfLink != nil {
+				got = *status.SelfLink
+			}
+			if got != tc.expected {
+				t.Errorf("SelfLink = %q, want %q", got, tc.expected)
+			}
+		})
+	}
+}
+
+// TestBigQueryDatasetSpec_FromProto_resourceID checks the resourceID derived
+// from FullID. Before the fix, a project ID containing a colon left resourceID
+// unset, and the create path failed outright.
+func TestBigQueryDatasetSpec_FromProto_resourceID(t *testing.T) {
+	tests := []struct {
+		name     string
+		fullID   string
+		expected string
+	}{
+		{
+			name:     "plainProjectID",
+			fullID:   "my-project:my_dataset",
+			expected: "my_dataset",
+		},
+		{
+			name:     "universeQualifiedProjectID",
+			fullID:   "my-universe:my-project:my_dataset",
+			expected: "my_dataset",
+		},
+		{
+			name:     "domainScopedProjectID",
+			fullID:   "example.com:my-project:my_dataset",
+			expected: "my_dataset",
+		},
+		{
+			name:     "malformedFullID_noResourceID",
+			fullID:   "my_dataset",
+			expected: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mapCtx := &direct.MapContext{}
+			spec := BigQueryDatasetSpec_FromProto(mapCtx, &pb.DatasetMetadata{FullID: tc.fullID})
+			if err := mapCtx.Err(); err != nil {
+				t.Fatalf("BigQueryDatasetSpec_FromProto returned error: %v", err)
+			}
+
+			got := ""
+			if spec.ResourceID != nil {
+				got = *spec.ResourceID
+			}
+			if got != tc.expected {
+				t.Errorf("ResourceID = %q, want %q", got, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/controller/direct/bigquerydataset/bigquerydataset_mappings_test.go
+++ b/pkg/controller/direct/bigquerydataset/bigquerydataset_mappings_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	pb "cloud.google.com/go/bigquery"
+	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/bigquery/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
 )
 
@@ -66,6 +67,56 @@ func TestBigQueryDatasetStatus_FromProto_selfLink(t *testing.T) {
 			}
 			if got != tc.expected {
 				t.Errorf("SelfLink = %q, want %q", got, tc.expected)
+			}
+		})
+	}
+}
+
+// TestBigQueryDatasetStatus_ToProto_fullID checks the inverse conversion.
+//
+// This previously used strings.Trim to strip the URL prefix. Trim takes a
+// cutset rather than a prefix, so it ate characters from both ends of the
+// link — "…/projects/my-project/datasets/my_dataset" became
+// "jects/my-project/datasets/my_d" — the "projects" guard never matched, and
+// FullID was silently never set.
+func TestBigQueryDatasetStatus_ToProto_fullID(t *testing.T) {
+	tests := []struct {
+		name     string
+		selfLink string
+		expected string
+	}{
+		{
+			name:     "plainProjectID",
+			selfLink: "https://bigquery.googleapis.com/bigquery/v2/projects/my-project/datasets/my_dataset",
+			expected: "my-project:my_dataset",
+		},
+		{
+			name:     "universeQualifiedProjectID",
+			selfLink: "https://bigquery.googleapis.com/bigquery/v2/projects/my-universe:my-project/datasets/my_dataset",
+			expected: "my-universe:my-project:my_dataset",
+		},
+		{
+			name:     "domainScopedProjectID",
+			selfLink: "https://bigquery.googleapis.com/bigquery/v2/projects/example.com:my-project/datasets/my_dataset",
+			expected: "example.com:my-project:my_dataset",
+		},
+		{
+			name:     "unexpectedShape_noFullID",
+			selfLink: "https://bigquery.googleapis.com/bigquery/v2/projects/my-project",
+			expected: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mapCtx := &direct.MapContext{}
+			selfLink := tc.selfLink
+			out := BigQueryDatasetStatus_ToProto(mapCtx, &krm.BigQueryDatasetStatus{SelfLink: &selfLink})
+			if err := mapCtx.Err(); err != nil {
+				t.Fatalf("BigQueryDatasetStatus_ToProto returned error: %v", err)
+			}
+			if out.FullID != tc.expected {
+				t.Errorf("FullID = %q, want %q", out.FullID, tc.expected)
 			}
 		})
 	}

--- a/pkg/controller/direct/bigquerydataset/utils.go
+++ b/pkg/controller/direct/bigquerydataset/utils.go
@@ -17,11 +17,35 @@ package bigquerydataset
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	bigquery "cloud.google.com/go/bigquery"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
+
+// parseDatasetFullID splits a BigQuery dataset FullID, which the API returns in
+// the form "projectID:datasetID", into its project and dataset parts.
+//
+// The project ID can itself contain a colon, so the split has to be on the
+// *last* one rather than on every one. Two project ID forms do this:
+//
+//	example.com:my-project     domain-scoped (legacy)
+//	my-universe:my-project     universe-qualified
+//
+// For those, "projectID:datasetID" has two colons, and splitting on all of them
+// yields three parts — losing the dataset. Splitting on the last colon is
+// correct for every form, including plain "my-project".
+//
+// ok is false when fullID is not in the expected form, including when either
+// part would be empty.
+func parseDatasetFullID(fullID string) (projectID, datasetID string, ok bool) {
+	i := strings.LastIndex(fullID, ":")
+	if i <= 0 || i == len(fullID)-1 {
+		return "", "", false
+	}
+	return fullID[:i], fullID[i+1:], true
+}
 
 func convertProtoToAPI(u protoreflect.ProtoMessage, v any) error {
 	if u == nil {

--- a/pkg/controller/direct/bigquerydataset/utils_test.go
+++ b/pkg/controller/direct/bigquerydataset/utils_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigquerydataset
+
+import "testing"
+
+func TestParseDatasetFullID(t *testing.T) {
+	tests := []struct {
+		name        string
+		fullID      string
+		wantProject string
+		wantDataset string
+		wantOK      bool
+	}{
+		{
+			name:        "plainProjectID",
+			fullID:      "my-project:my_dataset",
+			wantProject: "my-project",
+			wantDataset: "my_dataset",
+			wantOK:      true,
+		},
+		{
+			// A universe-qualified project ID contains a colon, so splitting on
+			// every colon yields three parts and drops the dataset.
+			name:        "universeQualifiedProjectID",
+			fullID:      "my-universe:my-project:my_dataset",
+			wantProject: "my-universe:my-project",
+			wantDataset: "my_dataset",
+			wantOK:      true,
+		},
+		{
+			// The same shape has existed in the public universe for years, via
+			// domain-scoped projects.
+			name:        "domainScopedProjectID",
+			fullID:      "example.com:my-project:my_dataset",
+			wantProject: "example.com:my-project",
+			wantDataset: "my_dataset",
+			wantOK:      true,
+		},
+		{
+			name:   "noColon",
+			fullID: "my_dataset",
+			wantOK: false,
+		},
+		{
+			name:   "empty",
+			fullID: "",
+			wantOK: false,
+		},
+		{
+			name:   "emptyProject",
+			fullID: ":my_dataset",
+			wantOK: false,
+		},
+		{
+			name:   "emptyDataset",
+			fullID: "my-project:",
+			wantOK: false,
+		},
+		{
+			name:   "onlyColon",
+			fullID: ":",
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			project, dataset, ok := parseDatasetFullID(tc.fullID)
+			if ok != tc.wantOK {
+				t.Fatalf("parseDatasetFullID(%q) ok = %v, want %v", tc.fullID, ok, tc.wantOK)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if project != tc.wantProject {
+				t.Errorf("parseDatasetFullID(%q) project = %q, want %q", tc.fullID, project, tc.wantProject)
+			}
+			if dataset != tc.wantDataset {
+				t.Errorf("parseDatasetFullID(%q) dataset = %q, want %q", tc.fullID, dataset, tc.wantDataset)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### BRIEF Change description

Fixes #12382

`BigQueryDataset` converts between BigQuery's `FullID` (`projectID:datasetID`) and a selfLink URL. Both directions are wrong when the project ID itself contains a colon.

**Direction 1 : `FullID` -> `resourceID` / `selfLink`.** Three call sites split `FullID` on every colon and require exactly two parts. A project ID can contain a colon:

| Form | Example `FullID` | Colons |
| :--- | :--- | ---: |
| plain | `my-project:my_dataset` | 1 |
| domain-scoped (legacy) | `example.com:my-project:my_dataset` | 2 |
| universe-qualified | `my-universe:my-project:my_dataset` | 2 |

For the latter two, create fails outright with `The full ID of the created BigQueryDataset is expected to be in the format of projectID:datasetID`, and the `resourceID` and `selfLink` mappings silently produce nothing.

Fixed by splitting on the *last* colon, via a shared `parseDatasetFullID` helper. Correct for every form, including the plain one.

**Direction 2 : selfLink -> `FullID`.** `BigQueryDatasetStatus_ToProto` stripped the URL prefix with `strings.Trim`, which takes a **cutset** rather than a prefix, so it removed characters from both ends:

```
in:  https://bigquery.googleapis.com/bigquery/v2/projects/my-project/datasets/my_dataset
out: jects/my-project/datasets/my_d
```

The following `tokens[0] == "projects"` guard therefore never matched, so `FullID` was silently never set — and had it matched, the dataset name was truncated. Changed to `strings.TrimPrefix`.

#### WHY do we need this change?

Direction 1 is a user-visible failure: creating a `BigQueryDataset` in a domain-scoped project (`example.com:my-project`) fails with an error saying the ID is malformed when it is valid. Domain-scoped project IDs have existed in public GCP for years.

Direction 2 is a silent correctness bug in the inverse mapping, affecting all projects.

I found these while working on universe support (#12374). Universe-qualified project IDs have the same shape as domain-scoped ones. But **neither fix is universe-specific**. Both are wrong in the public universe today, and neither needs any configuration.

#### Special notes for your reviewer:

The two fixes are in separate commits, so the second can be dropped if you would rather it went separately. I kept them together because they are the two directions of the same conversion, in the same file, and fixing only one would leave the pair inconsistent.

`strings.Split(selfLink, "/")` in direction 2 is left as-is and is correct. Project IDs cannot contain `/`, so a colon inside one survives the split intact.

No API, schema, or behavioural change for project IDs without a colon. `parseDatasetFullID` returns `ok=false` for malformed input, preserving the existing error path in the controller.

#### Does this PR add something which needs to be 'release noted'?

```release-note
Fixed BigQueryDataset failing to reconcile in projects whose project ID contains a colon, such as domain-scoped projects (`example.com:my-project`). Creation previously failed with "The full ID of the created BigQueryDataset is expected to be in the format of projectID:datasetID", and the `resourceID` and `selfLink` fields were not populated.
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

```docs

```

#### Intended Milestone

No preference. Self-contained bug fix, no API change.

- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

New unit tests:

- `pkg/controller/direct/bigquerydataset/utils_test.go` : `parseDatasetFullID` across plain, domain-scoped and universe-qualified project IDs, plus rejection cases (no colon, empty, empty project, empty dataset, bare colon).
- `pkg/controller/direct/bigquerydataset/bigquerydataset_mappings_test.go` : `resourceID` and `selfLink` derived from `FullID`, and `FullID` derived back from a selfLink, each across all three project ID forms and a malformed input.

```
$ go test ./pkg/controller/direct/bigquerydataset/...
ok  	github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/bigquerydataset

25 passed, including the pre-existing fuzz roundtrip tests.

$ go vet ./pkg/controller/direct/bigquerydataset/...
$ gofmt -l pkg/controller/direct/bigquerydataset/     # clean
```

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.