### PR TITLE
test: Allow plural zones, regions, and locations to not require refs in cr…

### DIFF
--- a/tests/apichecks/crds_test.go
+++ b/tests/apichecks/crds_test.go
@@ -121,9 +121,11 @@ func TestMissingRefs(t *testing.T) {
 				if isRef {
 					// We don't require refs for zones or regions, nor for instanceTypes
 					switch {
-					case strings.HasSuffix(fieldPath, ".zone"):
+					case strings.HasSuffix(fieldPath, ".zone"), strings.HasSuffix(fieldPath, ".zones"):
 						// ok
-					case strings.HasSuffix(fieldPath, ".location"):
+					case strings.HasSuffix(fieldPath, ".region"), strings.HasSuffix(fieldPath, ".regions"):
+						// ok
+					case strings.HasSuffix(fieldPath, ".location"), strings.HasSuffix(fieldPath, ".locations"):
 						// ok
 					case strings.HasSuffix(fieldPath, ".machineType"):
 						// ok

--- a/tests/apichecks/testdata/exceptions/missingrefs.txt
+++ b/tests/apichecks/testdata/exceptions/missingrefs.txt
@@ -13,7 +13,6 @@
 [refs] crd=beyondcorpappconnectors.beyondcorp.cnrm.cloud.google.com version=v1alpha1: field ".spec.principalInfo.serviceAccount" should be a reference
 [refs] crd=bigquerydatapolicydatapolicies.bigquerydatapolicy.cnrm.cloud.google.com version=v1alpha1: field ".spec.policyTag" should be a reference
 [refs] crd=bigquerytables.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.externalDataConfiguration.connectionId" should be a reference
-[refs] crd=bigtabletables.bigtable.cnrm.cloud.google.com version=v1beta1: field ".spec.automatedBackupPolicy.locations" should be a reference
 [refs] crd=billingbudgetsbudgets.billingbudgets.cnrm.cloud.google.com version=v1beta1: field ".spec.allUpdatesRule.monitoringNotificationChannels[].external" should be a reference
 [refs] crd=binaryauthorizationpolicies.binaryauthorization.cnrm.cloud.google.com version=v1beta1: field ".spec.defaultAdmissionRule.requireAttestationsBy[].external" should be a reference
 [refs] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.build.options.workerPool" should be a reference


### PR DESCRIPTION
…ds_test.go

### BRIEF Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Followup of https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/12363#discussion_r3785914160

- Updates TestMissingRefs in tests/apichecks/crds_test.go to ignore .zones, .regions, and .locations field suffixes from requiring resource reference check
- Regenerates the exceptions file tests/apichecks/testdata/exceptions/missingrefs.txt, remove .spec.automatedBackupPolicy.locations in BigtableTable.


#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
