### PR TITLE
ci: set CLOUDSDK_CORE_PROJECT and ignore gcloud errors in unit-tests

### DIFF
--- a/dev/ci/presubmits/unit-tests
+++ b/dev/ci/presubmits/unit-tests
@@ -29,7 +29,8 @@ cd ${REPO_ROOT}
 . ${REPO_ROOT}/dev/tasks/setup-envtest
 
 # A dummy default project id is required for a few unit test cases
-gcloud config set project foobar --quiet
+export CLOUDSDK_CORE_PROJECT=foobar
+gcloud config set project foobar --quiet 2>/dev/null || true
 
 # Env var VALIDATE_URLS needs to be unset to avoid calling URLs in TestReferenceDocConsistency under scripts/generate-google3-docs/.
 unset VALIDATE_URLS


### PR DESCRIPTION
Sets `CLOUDSDK_CORE_PROJECT=foobar` and ignores non-zero exit codes from `gcloud config set project foobar` in the `dev/ci/presubmits/unit-tests` script to ensure a valid dummy GCP project is configured for unit tests without failing in constrained CI environments.