### PR TITLE
Fix NSTlsInspectionPolicy and verify against realGCP

### DIFF
--- a/dev/tasks/build-release-bundle
+++ b/dev/tasks/build-release-bundle
@@ -210,7 +210,6 @@ BLOCKED_KINDS=(
     "NetworkSecurityMirroringEndpointGroupAssociation"
     "NetworkSecurityPartnerSSEGateway"
     "NetworkSecurityPartnerSSERealm"
-    "NetworkSecurityTlsInspectionPolicy"
     "NetworkSecurityUrlList"
     "NetworkServicesAuthzExtension"
     "NotebookRuntime"

--- a/mockgcp/mocknetworksecurity/tlsinspectionpolicy.go
+++ b/mockgcp/mocknetworksecurity/tlsinspectionpolicy.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"time"
 
+	"google.golang.org/protobuf/types/known/emptypb"
+
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
 
 	pbv1 "cloud.google.com/go/networksecurity/apiv1/networksecuritypb"
@@ -145,7 +147,7 @@ func (s *NetworkSecurityV1Server) DeleteTlsInspectionPolicy(ctx context.Context,
 
 	lroPrefix := fmt.Sprintf("projects/%s/locations/%s", name.Project.ID, name.Location)
 	return s.operations.StartLRO(ctx, lroPrefix, metadata, func() (proto.Message, error) {
-		return deleted, nil
+		return &emptypb.Empty{}, nil
 	})
 }
 

--- a/mockgcp/mocknetworksecurity/tlsinspectionpolicy.go
+++ b/mockgcp/mocknetworksecurity/tlsinspectionpolicy.go
@@ -16,7 +16,11 @@ package mocknetworksecurity
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"time"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
 
 	pbv1 "cloud.google.com/go/networksecurity/apiv1/networksecuritypb"
 	"google.golang.org/genproto/googleapis/longrunning"
@@ -32,9 +36,12 @@ type NetworkSecurityV1Server struct {
 }
 
 func (s *NetworkSecurityV1Server) CreateTlsInspectionPolicy(ctx context.Context, req *pbv1.CreateTlsInspectionPolicyRequest) (*longrunning.Operation, error) {
-	name := req.Parent + "/tlsInspectionPolicies/" + req.TlsInspectionPolicyId
+	name, err := s.parseTlsInspectionPolicyName(req.Parent + "/tlsInspectionPolicies/" + req.TlsInspectionPolicyId)
+	if err != nil {
+		return nil, err
+	}
 
-	fqn := name
+	fqn := name.String()
 
 	obj := proto.Clone(req.TlsInspectionPolicy).(*pbv1.TlsInspectionPolicy)
 	obj.Name = fqn
@@ -46,18 +53,25 @@ func (s *NetworkSecurityV1Server) CreateTlsInspectionPolicy(ctx context.Context,
 	}
 
 	metadata := &pbv1.OperationMetadata{
+		ApiVersion: "v1",
 		CreateTime: obj.CreateTime,
 		Target:     fqn,
 		Verb:       "create",
 	}
 
-	return s.operations.StartLRO(ctx, fqn, metadata, func() (proto.Message, error) {
+	lroPrefix := fmt.Sprintf("projects/%s/locations/%s", name.Project.ID, name.Location)
+	return s.operations.StartLRO(ctx, lroPrefix, metadata, func() (proto.Message, error) {
 		return obj, nil
 	})
 }
 
 func (s *NetworkSecurityV1Server) GetTlsInspectionPolicy(ctx context.Context, req *pbv1.GetTlsInspectionPolicyRequest) (*pbv1.TlsInspectionPolicy, error) {
-	fqn := req.Name
+	name, err := s.parseTlsInspectionPolicyName(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
 
 	obj := &pbv1.TlsInspectionPolicy{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
@@ -71,7 +85,12 @@ func (s *NetworkSecurityV1Server) GetTlsInspectionPolicy(ctx context.Context, re
 }
 
 func (s *NetworkSecurityV1Server) UpdateTlsInspectionPolicy(ctx context.Context, req *pbv1.UpdateTlsInspectionPolicyRequest) (*longrunning.Operation, error) {
-	fqn := req.TlsInspectionPolicy.GetName()
+	name, err := s.parseTlsInspectionPolicyName(req.TlsInspectionPolicy.GetName())
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
 
 	actual := &pbv1.TlsInspectionPolicy{}
 	if err := s.storage.Get(ctx, fqn, actual); err != nil {
@@ -87,18 +106,25 @@ func (s *NetworkSecurityV1Server) UpdateTlsInspectionPolicy(ctx context.Context,
 	}
 
 	metadata := &pbv1.OperationMetadata{
+		ApiVersion: "v1",
 		CreateTime: updated.CreateTime,
 		Target:     fqn,
 		Verb:       "update",
 	}
 
-	return s.operations.StartLRO(ctx, fqn, metadata, func() (proto.Message, error) {
+	lroPrefix := fmt.Sprintf("projects/%s/locations/%s", name.Project.ID, name.Location)
+	return s.operations.StartLRO(ctx, lroPrefix, metadata, func() (proto.Message, error) {
 		return updated, nil
 	})
 }
 
 func (s *NetworkSecurityV1Server) DeleteTlsInspectionPolicy(ctx context.Context, req *pbv1.DeleteTlsInspectionPolicyRequest) (*longrunning.Operation, error) {
-	fqn := req.Name
+	name, err := s.parseTlsInspectionPolicyName(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
 
 	actual := &pbv1.TlsInspectionPolicy{}
 	if err := s.storage.Get(ctx, fqn, actual); err != nil {
@@ -111,12 +137,42 @@ func (s *NetworkSecurityV1Server) DeleteTlsInspectionPolicy(ctx context.Context,
 	}
 
 	metadata := &pbv1.OperationMetadata{
+		ApiVersion: "v1",
 		CreateTime: actual.CreateTime,
 		Target:     fqn,
 		Verb:       "delete",
 	}
 
-	return s.operations.StartLRO(ctx, fqn, metadata, func() (proto.Message, error) {
+	lroPrefix := fmt.Sprintf("projects/%s/locations/%s", name.Project.ID, name.Location)
+	return s.operations.StartLRO(ctx, lroPrefix, metadata, func() (proto.Message, error) {
 		return deleted, nil
 	})
+}
+
+type TlsInspectionPolicyName struct {
+	Project             *projects.ProjectData
+	Location            string
+	TlsInspectionPolicy string
+}
+
+func (n *TlsInspectionPolicyName) String() string {
+	return "projects/" + n.Project.ID + "/locations/" + n.Location + "/tlsInspectionPolicies/" + n.TlsInspectionPolicy
+}
+
+func (s *NetworkSecurityV1Server) parseTlsInspectionPolicyName(name string) (*TlsInspectionPolicyName, error) {
+	tokens := strings.Split(name, "/")
+	if len(tokens) == 6 && tokens[0] == "projects" && tokens[2] == "locations" && tokens[4] == "tlsInspectionPolicies" {
+		project, err := s.Projects.GetProject(&projects.ProjectName{ProjectID: tokens[1]})
+		if err != nil {
+			return nil, err
+		}
+		name := &TlsInspectionPolicyName{
+			Project:             project,
+			Location:            tokens[3],
+			TlsInspectionPolicy: tokens[5],
+		}
+		return name, nil
+	} else {
+		return nil, status.Errorf(codes.InvalidArgument, "name %q is not valid", name)
+	}
 }

--- a/pkg/controller/direct/networksecurity/mapper.generated.go
+++ b/pkg/controller/direct/networksecurity/mapper.generated.go
@@ -1524,40 +1524,6 @@ func NetworkSecurityTLSInspectionPolicyObservedState_v1alpha1_ToProto(mapCtx *di
 	// MISSING: CAPool
 	return out
 }
-func NetworkSecurityTLSInspectionPolicySpec_v1alpha1_FromProto(mapCtx *direct.MapContext, in *pb.TlsInspectionPolicy) *krmnetworksecurityv1alpha1.NetworkSecurityTLSInspectionPolicySpec {
-	if in == nil {
-		return nil
-	}
-	out := &krmnetworksecurityv1alpha1.NetworkSecurityTLSInspectionPolicySpec{}
-	// MISSING: Name
-	out.Description = direct.LazyPtr(in.GetDescription())
-	// MISSING: CAPool
-	if in.GetTrustConfig() != "" {
-		out.TrustConfigRef = &krmcertificatemanagerv1alpha1.CertificateManagerTrustConfigRef{External: in.GetTrustConfig()}
-	}
-	out.ExcludePublicCASet = in.ExcludePublicCaSet
-	out.MinTLSVersion = direct.Enum_FromProto(mapCtx, in.GetMinTlsVersion())
-	out.TLSFeatureProfile = direct.Enum_FromProto(mapCtx, in.GetTlsFeatureProfile())
-	out.CustomTLSFeatures = in.CustomTlsFeatures
-	return out
-}
-func NetworkSecurityTLSInspectionPolicySpec_v1alpha1_ToProto(mapCtx *direct.MapContext, in *krmnetworksecurityv1alpha1.NetworkSecurityTLSInspectionPolicySpec) *pb.TlsInspectionPolicy {
-	if in == nil {
-		return nil
-	}
-	out := &pb.TlsInspectionPolicy{}
-	// MISSING: Name
-	out.Description = direct.ValueOf(in.Description)
-	// MISSING: CAPool
-	if in.TrustConfigRef != nil {
-		out.TrustConfig = in.TrustConfigRef.External
-	}
-	out.ExcludePublicCaSet = in.ExcludePublicCASet
-	out.MinTlsVersion = direct.Enum_ToProto[pb.TlsInspectionPolicy_TlsVersion](mapCtx, in.MinTLSVersion)
-	out.TlsFeatureProfile = direct.Enum_ToProto[pb.TlsInspectionPolicy_Profile](mapCtx, in.TLSFeatureProfile)
-	out.CustomTlsFeatures = in.CustomTLSFeatures
-	return out
-}
 func NetworkSecurityURLListObservedState_v1alpha1_FromProto(mapCtx *direct.MapContext, in *pb.UrlList) *krmnetworksecurityv1alpha1.NetworkSecurityURLListObservedState {
 	if in == nil {
 		return nil

--- a/pkg/controller/direct/networksecurity/networksecuritytlsinspectionpolicy_controller.go
+++ b/pkg/controller/direct/networksecurity/networksecuritytlsinspectionpolicy_controller.go
@@ -17,7 +17,6 @@ package networksecurity
 import (
 	"context"
 	"fmt"
-	"time"
 
 	certificatemanagerv1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/certificatemanager/v1alpha1"
 
@@ -31,10 +30,9 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/structuredreporting"
 
+	networksecurity "cloud.google.com/go/networksecurity/apiv1"
 	pb "cloud.google.com/go/networksecurity/apiv1/networksecuritypb"
 	"google.golang.org/api/option"
-	"google.golang.org/api/transport/grpc"
-	longrunningpb "google.golang.org/genproto/googleapis/longrunning"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -56,18 +54,19 @@ type tlsInspectionPolicyModel struct {
 	config config.ControllerConfig
 }
 
-func (m *tlsInspectionPolicyModel) client(ctx context.Context) (pb.NetworkSecurityClient, longrunningpb.OperationsClient, error) {
+func (m *tlsInspectionPolicyModel) client(ctx context.Context) (*networksecurity.Client, error) {
 	var opts []option.ClientOption
 	opts, err := m.config.GRPCClientOptions()
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	opts = append(opts, option.WithEndpoint("networksecurity.googleapis.com:443"))
-	conn, err := grpc.Dial(ctx, opts...)
+
+	gcpClient, err := networksecurity.NewClient(ctx, opts...)
 	if err != nil {
-		return nil, nil, fmt.Errorf("dialing networksecurity service: %w", err)
+		return nil, fmt.Errorf("building NetworkSecurity client: %w", err)
 	}
-	return pb.NewNetworkSecurityClient(conn), longrunningpb.NewOperationsClient(conn), nil
+
+	return gcpClient, nil
 }
 
 func (m *tlsInspectionPolicyModel) AdapterForObject(ctx context.Context, op *directbase.AdapterForObjectOperation) (directbase.Adapter, error) {
@@ -87,7 +86,7 @@ func (m *tlsInspectionPolicyModel) AdapterForObject(ctx context.Context, op *dir
 		return nil, err
 	}
 
-	gcpClient, operationsClient, err := m.client(ctx)
+	gcpClient, err := m.client(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -99,18 +98,11 @@ func (m *tlsInspectionPolicyModel) AdapterForObject(ctx context.Context, op *dir
 	}
 
 	desired.Name = id.(*krm.NetworkSecurityTLSInspectionPolicyIdentity).String()
-	if obj.Spec.CaPoolRef != nil {
-		desired.CaPool = obj.Spec.CaPoolRef.External
-	}
-	if obj.Spec.TrustConfigRef != nil {
-		desired.TrustConfig = obj.Spec.TrustConfigRef.External
-	}
 
 	return &tlsInspectionPolicyAdapter{
-		id:               id.(*krm.NetworkSecurityTLSInspectionPolicyIdentity),
-		gcpClient:        gcpClient,
-		operationsClient: operationsClient,
-		desired:          desired,
+		id:        id.(*krm.NetworkSecurityTLSInspectionPolicyIdentity),
+		gcpClient: gcpClient,
+		desired:   desired,
 	}, nil
 }
 
@@ -119,11 +111,10 @@ func (m *tlsInspectionPolicyModel) AdapterForURL(ctx context.Context, url string
 }
 
 type tlsInspectionPolicyAdapter struct {
-	id               *krm.NetworkSecurityTLSInspectionPolicyIdentity
-	gcpClient        pb.NetworkSecurityClient
-	operationsClient longrunningpb.OperationsClient
-	desired          *pb.TlsInspectionPolicy
-	actual           *pb.TlsInspectionPolicy
+	id        *krm.NetworkSecurityTLSInspectionPolicyIdentity
+	gcpClient *networksecurity.Client
+	desired   *pb.TlsInspectionPolicy
+	actual    *pb.TlsInspectionPolicy
 }
 
 var _ directbase.Adapter = &tlsInspectionPolicyAdapter{}
@@ -159,19 +150,13 @@ func (a *tlsInspectionPolicyAdapter) Create(ctx context.Context, createOp *direc
 		return fmt.Errorf("creating TlsInspectionPolicy %s: %w", a.id, err)
 	}
 
-	err = a.waitForOperation(ctx, op)
+	created, err := op.Wait(ctx)
 	if err != nil {
-		return fmt.Errorf("TlsInspectionPolicy %s waiting creation: %w", a.id, err)
+		return fmt.Errorf("creating TlsInspectionPolicy %s: %w", a.id, err)
 	}
-
-	latest, err := a.gcpClient.GetTlsInspectionPolicy(ctx, &pb.GetTlsInspectionPolicyRequest{Name: a.id.String()})
-	if err != nil {
-		return fmt.Errorf("getting TlsInspectionPolicy after creation: %w", err)
-	}
-
 	log.V(2).Info("successfully created TlsInspectionPolicy", "name", a.id)
 
-	return a.updateStatus(ctx, createOp, latest)
+	return a.updateStatus(ctx, createOp, created)
 }
 
 func (a *tlsInspectionPolicyAdapter) Update(ctx context.Context, updateOp *directbase.UpdateOperation) error {
@@ -186,36 +171,29 @@ func (a *tlsInspectionPolicyAdapter) Update(ctx context.Context, updateOp *direc
 	diffs.Object = updateOp.GetUnstructured()
 	structuredreporting.ReportDiff(ctx, diffs)
 
+	updated := a.actual
 	if !diffs.HasDiff() {
 		log.V(2).Info("no field needs update", "name", a.id)
-		return nil
+	} else {
+		log.V(2).Info("fields need update", "name", a.id, "updateMask", updateMask)
+		req := &pb.UpdateTlsInspectionPolicyRequest{
+			UpdateMask:          updateMask,
+			TlsInspectionPolicy: a.desired,
+		}
+		req.TlsInspectionPolicy.Name = a.id.String()
+
+		op, err := a.gcpClient.UpdateTlsInspectionPolicy(ctx, req)
+		if err != nil {
+			return fmt.Errorf("updating TlsInspectionPolicy %s: %w", a.id, err)
+		}
+		updated, err = op.Wait(ctx)
+		if err != nil {
+			return fmt.Errorf("creating TlsInspectionPolicy %s: %w", a.id, err)
+		}
+		log.V(2).Info("successfully updated TlsInspectionPolicy", "name", a.id)
 	}
 
-	log.V(2).Info("fields need update", "name", a.id, "updateMask", updateMask)
-
-	req := &pb.UpdateTlsInspectionPolicyRequest{
-		UpdateMask:          updateMask,
-		TlsInspectionPolicy: a.desired,
-	}
-	req.TlsInspectionPolicy.Name = a.id.String()
-
-	op, err := a.gcpClient.UpdateTlsInspectionPolicy(ctx, req)
-	if err != nil {
-		return fmt.Errorf("updating TlsInspectionPolicy %s: %w", a.id, err)
-	}
-	err = a.waitForOperation(ctx, op)
-	if err != nil {
-		return fmt.Errorf("TlsInspectionPolicy %s waiting update: %w", a.id, err)
-	}
-
-	latest, err := a.gcpClient.GetTlsInspectionPolicy(ctx, &pb.GetTlsInspectionPolicyRequest{Name: a.id.String()})
-	if err != nil {
-		return fmt.Errorf("getting TlsInspectionPolicy after update: %w", err)
-	}
-
-	log.V(2).Info("successfully updated TlsInspectionPolicy", "name", a.id)
-
-	return a.updateStatus(ctx, updateOp, latest)
+	return a.updateStatus(ctx, updateOp, updated)
 }
 
 func compareTlsInspectionPolicy(ctx context.Context, actual, desired *pb.TlsInspectionPolicy) (*structuredreporting.Diff, *fieldmaskpb.FieldMask, error) {
@@ -229,8 +207,6 @@ func compareTlsInspectionPolicy(ctx context.Context, actual, desired *pb.TlsInsp
 		return nil, nil, mapCtx.Err()
 	}
 	maskedActual.Name = desired.Name
-	maskedActual.CaPool = actual.CaPool
-	maskedActual.TrustConfig = actual.TrustConfig
 
 	diffs, updateMask, err := common.DiffForTopLevelFields(ctx, desired.ProtoReflect(), maskedActual.ProtoReflect())
 	if err != nil {
@@ -287,7 +263,7 @@ func (a *tlsInspectionPolicyAdapter) Delete(ctx context.Context, deleteOp *direc
 		return false, fmt.Errorf("deleting TlsInspectionPolicy %s: %w", a.id, err)
 	}
 
-	err = a.waitForOperation(ctx, op)
+	err = op.Wait(ctx)
 	if err != nil {
 		return false, fmt.Errorf("waiting delete TlsInspectionPolicy %s: %w", a.id, err)
 	}
@@ -305,27 +281,4 @@ func (a *tlsInspectionPolicyAdapter) updateStatus(ctx context.Context, op direct
 	}
 	status.ExternalRef = direct.LazyPtr(a.id.String())
 	return op.UpdateStatus(ctx, status, nil)
-}
-
-func (a *tlsInspectionPolicyAdapter) waitForOperation(ctx context.Context, op *longrunningpb.Operation) error {
-	for {
-		req := &longrunningpb.GetOperationRequest{
-			Name: op.GetName(),
-		}
-		current, err := a.operationsClient.GetOperation(ctx, req)
-		if err != nil {
-			return fmt.Errorf("getting operation %q: %w", op.GetName(), err)
-		}
-		if current.GetDone() {
-			if current.GetError() != nil {
-				return fmt.Errorf("operation failed: %s", current.GetError().GetMessage())
-			}
-			return nil
-		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(1 * time.Second):
-		}
-	}
 }

--- a/pkg/controller/direct/networksecurity/networksecuritytlsinspectionpolicy_controller.go
+++ b/pkg/controller/direct/networksecurity/networksecuritytlsinspectionpolicy_controller.go
@@ -56,12 +56,12 @@ type tlsInspectionPolicyModel struct {
 
 func (m *tlsInspectionPolicyModel) client(ctx context.Context) (*networksecurity.Client, error) {
 	var opts []option.ClientOption
-	opts, err := m.config.GRPCClientOptions()
+	opts, err := m.config.RESTClientOptions()
 	if err != nil {
 		return nil, err
 	}
 
-	gcpClient, err := networksecurity.NewClient(ctx, opts...)
+	gcpClient, err := networksecurity.NewRESTClient(ctx, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("building NetworkSecurity client: %w", err)
 	}

--- a/pkg/controller/direct/networksecurity/networksecuritytlsinspectionpolicy_mapper.go
+++ b/pkg/controller/direct/networksecurity/networksecuritytlsinspectionpolicy_mapper.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networksecurity
+
+import (
+	pb "cloud.google.com/go/networksecurity/apiv1/networksecuritypb"
+	krmcertificatemanagerv1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/certificatemanager/v1alpha1"
+	krmnetworksecurityv1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/networksecurity/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/privateca/privatecarefs"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
+)
+
+func NetworkSecurityTLSInspectionPolicySpec_v1alpha1_FromProto(mapCtx *direct.MapContext, in *pb.TlsInspectionPolicy) *krmnetworksecurityv1alpha1.NetworkSecurityTLSInspectionPolicySpec {
+	if in == nil {
+		return nil
+	}
+	out := &krmnetworksecurityv1alpha1.NetworkSecurityTLSInspectionPolicySpec{}
+	// MISSING: Name
+	out.Description = direct.LazyPtr(in.GetDescription())
+	if in.GetCaPool() != "" {
+		out.CaPoolRef = &privatecarefs.PrivateCACAPoolRef{External: in.GetCaPool()}
+	}
+	if in.GetTrustConfig() != "" {
+		out.TrustConfigRef = &krmcertificatemanagerv1alpha1.CertificateManagerTrustConfigRef{External: in.GetTrustConfig()}
+	}
+	out.ExcludePublicCASet = in.ExcludePublicCaSet
+	out.MinTLSVersion = direct.Enum_FromProto(mapCtx, in.GetMinTlsVersion())
+	out.TLSFeatureProfile = direct.Enum_FromProto(mapCtx, in.GetTlsFeatureProfile())
+	out.CustomTLSFeatures = in.CustomTlsFeatures
+	return out
+}
+func NetworkSecurityTLSInspectionPolicySpec_v1alpha1_ToProto(mapCtx *direct.MapContext, in *krmnetworksecurityv1alpha1.NetworkSecurityTLSInspectionPolicySpec) *pb.TlsInspectionPolicy {
+	if in == nil {
+		return nil
+	}
+	out := &pb.TlsInspectionPolicy{}
+	// MISSING: Name
+	out.Description = direct.ValueOf(in.Description)
+	if in.CaPoolRef != nil {
+		out.CaPool = privatecarefs.StripCAPoolPrefix(in.CaPoolRef.External)
+	}
+	if in.TrustConfigRef != nil {
+		out.TrustConfig = in.TrustConfigRef.External
+	}
+	out.ExcludePublicCaSet = in.ExcludePublicCASet
+	out.MinTlsVersion = direct.Enum_ToProto[pb.TlsInspectionPolicy_TlsVersion](mapCtx, in.MinTLSVersion)
+	out.TlsFeatureProfile = direct.Enum_ToProto[pb.TlsInspectionPolicy_Profile](mapCtx, in.TLSFeatureProfile)
+	out.CustomTlsFeatures = in.CustomTLSFeatures
+	return out
+}

--- a/pkg/test/resourcefixture/golden_alignment_test.go
+++ b/pkg/test/resourcefixture/golden_alignment_test.go
@@ -752,6 +752,12 @@ func normalizeRepresentation(obj interface{}) interface{} {
 		if v["logConfig"] == nil {
 			delete(v, "logConfig")
 		}
+		if slice, ok := v["customTlsFeatures"].([]interface{}); ok && len(slice) == 0 {
+			delete(v, "customTlsFeatures")
+		}
+		if val, ok := v["trustConfig"].(string); ok && val == "" {
+			delete(v, "trustConfig")
+		}
 		if val, ok := v["icmpIdleTimeoutSec"].(float64); ok && val == 30 {
 			delete(v, "icmpIdleTimeoutSec")
 		}

--- a/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-basic/_generated_object_tlsinspectionpolicy-basic.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-basic/_generated_object_tlsinspectionpolicy-basic.golden.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: ${uniqueId}
 spec:
   caPoolRef:
-    name: capool-${uniqueId}
+    external: projects/${projectId}/locations/us-central1/caPools/capool-dep-2
   description: An updated TLS Inspection Policy to decrypt traffic
   excludePublicCASet: true
   location: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-basic/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-basic/_http.log
@@ -4,7 +4,7 @@ GRPC /google.cloud.networksecurity.v1.NetworkSecurity/GetTlsInspectionPolicy
   "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}"
 }
 
-error: rpc error: code = NotFound desc = TlsInspectionPolicy "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}" not found
+error: rpc error: code = NotFound desc = Resource 'projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}' was not found
 
 {}
 
@@ -54,6 +54,7 @@ OK
     "@type": "type.googleapis.com/google.cloud.networksecurity.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "endTime": "2024-04-01T12:34:56.123456Z",
     "target": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
     "verb": "create"
   },
@@ -137,6 +138,7 @@ OK
     "@type": "type.googleapis.com/google.cloud.networksecurity.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "endTime": "2024-04-01T12:34:56.123456Z",
     "target": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
     "verb": "update"
   },
@@ -233,19 +235,12 @@ OK
     "@type": "type.googleapis.com/google.cloud.networksecurity.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "endTime": "2024-04-01T12:34:56.123456Z",
     "target": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
     "verb": "delete"
   },
   "name": "projects/${projectId}/locations/us-central1/operations/${operationID}",
   "response": {
-    "@type": "type.googleapis.com/google.cloud.networksecurity.v1.TlsInspectionPolicy",
-    "caPool": "projects/${projectId}/locations/us-central1/caPools/capool-dep-2",
-    "createTime": "2024-04-01T12:34:56.123456Z",
-    "description": "An updated TLS Inspection Policy to decrypt traffic",
-    "excludePublicCaSet": true,
-    "minTlsVersion": "TLS_1_2",
-    "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
-    "tlsFeatureProfile": "PROFILE_COMPATIBLE",
-    "updateTime": "2024-04-01T12:34:56.123456Z"
+    "@type": "type.googleapis.com/google.protobuf.Empty"
   }
 }

--- a/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-basic/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-basic/_http.log
@@ -1,37 +1,59 @@
-GRPC /google.cloud.networksecurity.v1.NetworkSecurity/GetTlsInspectionPolicy
+GET https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FtlsInspectionPolicies%2Ftlsinspection-${uniqueId}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
 
 {
-  "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}"
+  "error": {
+    "code": 404,
+    "message": "Resource 'projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}' was not found",
+    "status": "NOT_FOUND"
+  }
 }
-
-error: rpc error: code = NotFound desc = Resource 'projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}' was not found
-
-{}
 
 ---
 
-GRPC /google.cloud.networksecurity.v1.NetworkSecurity/CreateTlsInspectionPolicy
+POST https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/tlsInspectionPolicies?%24alt=json%3Benum-encoding%3Dint&tlsInspectionPolicyId=tlsinspection-${uniqueId}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1
 
 {
-  "parent": "projects/${projectId}/locations/us-central1",
-  "tlsInspectionPolicy": {
-    "caPool": "projects/${projectId}/locations/us-central1/caPools/capool-dep-1",
-    "description": "A TLS Inspection Policy to decrypt traffic",
-    "excludePublicCaSet": true,
-    "minTlsVersion": "TLS_1_2",
-    "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
-    "tlsFeatureProfile": "PROFILE_COMPATIBLE"
-  },
-  "tlsInspectionPolicyId": "tlsinspection-${uniqueId}"
+  "caPool": "projects/${projectId}/locations/us-central1/caPools/capool-dep-1",
+  "description": "A TLS Inspection Policy to decrypt traffic",
+  "excludePublicCaSet": true,
+  "minTlsVersion": 3,
+  "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
+  "tlsFeatureProfile": 1
 }
 
-OK
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
 
 {
+  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.networksecurity.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
     "verb": "create"
   },
@@ -40,13 +62,20 @@ OK
 
 ---
 
-GRPC /google.longrunning.Operations/GetOperation
+GET https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Foperations%2F${operationID}
 
-{
-  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
-}
-
-OK
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
 
 {
   "done": true,
@@ -55,6 +84,7 @@ OK
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
     "verb": "create"
   },
@@ -74,48 +104,67 @@ OK
 
 ---
 
-GRPC /google.cloud.networksecurity.v1.NetworkSecurity/GetTlsInspectionPolicy
+GET https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FtlsInspectionPolicies%2Ftlsinspection-${uniqueId}
 
-{
-  "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}"
-}
-
-OK
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
 
 {
   "caPool": "projects/${projectId}/locations/us-central1/caPools/capool-dep-1",
   "createTime": "2024-04-01T12:34:56.123456Z",
+  "customTlsFeatures": [],
   "description": "A TLS Inspection Policy to decrypt traffic",
   "excludePublicCaSet": true,
-  "minTlsVersion": "TLS_1_2",
+  "minTlsVersion": 3,
   "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
-  "tlsFeatureProfile": "PROFILE_COMPATIBLE",
+  "tlsFeatureProfile": 1,
+  "trustConfig": "",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }
 
 ---
 
-GRPC /google.cloud.networksecurity.v1.NetworkSecurity/UpdateTlsInspectionPolicy
+PATCH https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}?%24alt=json%3Benum-encoding%3Dint&updateMask=caPool%2Cdescription
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: tls_inspection_policy.name=projects%2F${projectId}%2Flocations%2Fus-central1%2FtlsInspectionPolicies%2Ftlsinspection-${uniqueId}
 
 {
-  "tlsInspectionPolicy": {
-    "caPool": "projects/${projectId}/locations/us-central1/caPools/capool-dep-2",
-    "description": "An updated TLS Inspection Policy to decrypt traffic",
-    "excludePublicCaSet": true,
-    "minTlsVersion": "TLS_1_2",
-    "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
-    "tlsFeatureProfile": "PROFILE_COMPATIBLE"
-  },
-  "updateMask": "caPool,description"
+  "caPool": "projects/${projectId}/locations/us-central1/caPools/capool-dep-2",
+  "description": "An updated TLS Inspection Policy to decrypt traffic",
+  "excludePublicCaSet": true,
+  "minTlsVersion": 3,
+  "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
+  "tlsFeatureProfile": 1
 }
 
-OK
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
 
 {
+  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.networksecurity.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
     "verb": "update"
   },
@@ -124,13 +173,20 @@ OK
 
 ---
 
-GRPC /google.longrunning.Operations/GetOperation
+GET https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Foperations%2F${operationID}
 
-{
-  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
-}
-
-OK
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
 
 {
   "done": true,
@@ -139,6 +195,7 @@ OK
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
     "verb": "update"
   },
@@ -158,61 +215,58 @@ OK
 
 ---
 
-GRPC /google.cloud.networksecurity.v1.NetworkSecurity/GetTlsInspectionPolicy
+GET https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FtlsInspectionPolicies%2Ftlsinspection-${uniqueId}
 
-{
-  "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}"
-}
-
-OK
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
 
 {
   "caPool": "projects/${projectId}/locations/us-central1/caPools/capool-dep-2",
   "createTime": "2024-04-01T12:34:56.123456Z",
+  "customTlsFeatures": [],
   "description": "An updated TLS Inspection Policy to decrypt traffic",
   "excludePublicCaSet": true,
-  "minTlsVersion": "TLS_1_2",
+  "minTlsVersion": 3,
   "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
-  "tlsFeatureProfile": "PROFILE_COMPATIBLE",
+  "tlsFeatureProfile": 1,
+  "trustConfig": "",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }
 
 ---
 
-GRPC /google.cloud.networksecurity.v1.NetworkSecurity/GetTlsInspectionPolicy
+DELETE https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FtlsInspectionPolicies%2Ftlsinspection-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
 
 {
-  "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}"
-}
-
-OK
-
-{
-  "caPool": "projects/${projectId}/locations/us-central1/caPools/capool-dep-2",
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "An updated TLS Inspection Policy to decrypt traffic",
-  "excludePublicCaSet": true,
-  "minTlsVersion": "TLS_1_2",
-  "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
-  "tlsFeatureProfile": "PROFILE_COMPATIBLE",
-  "updateTime": "2024-04-01T12:34:56.123456Z"
-}
-
----
-
-GRPC /google.cloud.networksecurity.v1.NetworkSecurity/DeleteTlsInspectionPolicy
-
-{
-  "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}"
-}
-
-OK
-
-{
+  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.networksecurity.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
     "verb": "delete"
   },
@@ -221,13 +275,20 @@ OK
 
 ---
 
-GRPC /google.longrunning.Operations/GetOperation
+GET https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Foperations%2F${operationID}
 
-{
-  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
-}
-
-OK
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
 
 {
   "done": true,
@@ -236,6 +297,7 @@ OK
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
     "verb": "delete"
   },

--- a/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-basic/_http_mock.log
+++ b/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-basic/_http_mock.log
@@ -287,14 +287,6 @@ X-Xss-Protection: 0
   },
   "name": "projects/${projectId}/locations/us-central1/operations/${operationID}",
   "response": {
-    "@type": "type.googleapis.com/google.cloud.networksecurity.v1.TlsInspectionPolicy",
-    "caPool": "projects/${projectId}/locations/us-central1/caPools/capool-dep-2",
-    "createTime": "2024-04-01T12:34:56.123456Z",
-    "description": "An updated TLS Inspection Policy to decrypt traffic",
-    "excludePublicCaSet": true,
-    "minTlsVersion": "TLS_1_2",
-    "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
-    "tlsFeatureProfile": "PROFILE_COMPATIBLE",
-    "updateTime": "2024-04-01T12:34:56.123456Z"
+    "@type": "type.googleapis.com/google.protobuf.Empty"
   }
 }

--- a/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-basic/_http_mock.log
+++ b/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-basic/_http_mock.log
@@ -1,31 +1,51 @@
-GRPC /google.cloud.networksecurity.v1.NetworkSecurity/GetTlsInspectionPolicy
+GET https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FtlsInspectionPolicies%2Ftlsinspection-${uniqueId}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
 
 {
-  "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}"
+  "error": {
+    "code": 404,
+    "message": "TlsInspectionPolicy \"projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}\" not found",
+    "status": "NOT_FOUND"
+  }
 }
-
-error: rpc error: code = NotFound desc = TlsInspectionPolicy "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}" not found
-
-{}
 
 ---
 
-GRPC /google.cloud.networksecurity.v1.NetworkSecurity/CreateTlsInspectionPolicy
+POST https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/tlsInspectionPolicies?%24alt=json%3Benum-encoding%3Dint&tlsInspectionPolicyId=tlsinspection-${uniqueId}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1
 
 {
-  "parent": "projects/${projectId}/locations/us-central1",
-  "tlsInspectionPolicy": {
-    "caPool": "projects/${projectId}/locations/us-central1/caPools/capool-dep-1",
-    "description": "A TLS Inspection Policy to decrypt traffic",
-    "excludePublicCaSet": true,
-    "minTlsVersion": "TLS_1_2",
-    "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
-    "tlsFeatureProfile": "PROFILE_COMPATIBLE"
-  },
-  "tlsInspectionPolicyId": "tlsinspection-${uniqueId}"
+  "caPool": "projects/${projectId}/locations/us-central1/caPools/capool-dep-1",
+  "description": "A TLS Inspection Policy to decrypt traffic",
+  "excludePublicCaSet": true,
+  "minTlsVersion": 3,
+  "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
+  "tlsFeatureProfile": 1
 }
 
-OK
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
 
 {
   "metadata": {
@@ -40,13 +60,20 @@ OK
 
 ---
 
-GRPC /google.longrunning.Operations/GetOperation
+GET https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Foperations%2F${operationID}
 
-{
-  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
-}
-
-OK
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
 
 {
   "done": true,
@@ -73,42 +100,57 @@ OK
 
 ---
 
-GRPC /google.cloud.networksecurity.v1.NetworkSecurity/GetTlsInspectionPolicy
+GET https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FtlsInspectionPolicies%2Ftlsinspection-${uniqueId}
 
-{
-  "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}"
-}
-
-OK
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
 
 {
   "caPool": "projects/${projectId}/locations/us-central1/caPools/capool-dep-1",
   "createTime": "2024-04-01T12:34:56.123456Z",
   "description": "A TLS Inspection Policy to decrypt traffic",
   "excludePublicCaSet": true,
-  "minTlsVersion": "TLS_1_2",
+  "minTlsVersion": 3,
   "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
-  "tlsFeatureProfile": "PROFILE_COMPATIBLE",
+  "tlsFeatureProfile": 1,
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }
 
 ---
 
-GRPC /google.cloud.networksecurity.v1.NetworkSecurity/UpdateTlsInspectionPolicy
+PATCH https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}?%24alt=json%3Benum-encoding%3Dint&updateMask=caPool%2Cdescription
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+X-Goog-Request-Params: tls_inspection_policy.name=projects%2F${projectId}%2Flocations%2Fus-central1%2FtlsInspectionPolicies%2Ftlsinspection-${uniqueId}
 
 {
-  "tlsInspectionPolicy": {
-    "caPool": "projects/${projectId}/locations/us-central1/caPools/capool-dep-2",
-    "description": "An updated TLS Inspection Policy to decrypt traffic",
-    "excludePublicCaSet": true,
-    "minTlsVersion": "TLS_1_2",
-    "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
-    "tlsFeatureProfile": "PROFILE_COMPATIBLE"
-  },
-  "updateMask": "caPool,description"
+  "caPool": "projects/${projectId}/locations/us-central1/caPools/capool-dep-2",
+  "description": "An updated TLS Inspection Policy to decrypt traffic",
+  "excludePublicCaSet": true,
+  "minTlsVersion": 3,
+  "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
+  "tlsFeatureProfile": 1
 }
 
-OK
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
 
 {
   "metadata": {
@@ -123,13 +165,20 @@ OK
 
 ---
 
-GRPC /google.longrunning.Operations/GetOperation
+GET https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Foperations%2F${operationID}
 
-{
-  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
-}
-
-OK
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
 
 {
   "done": true,
@@ -156,55 +205,48 @@ OK
 
 ---
 
-GRPC /google.cloud.networksecurity.v1.NetworkSecurity/GetTlsInspectionPolicy
+GET https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FtlsInspectionPolicies%2Ftlsinspection-${uniqueId}
 
-{
-  "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}"
-}
-
-OK
-
-{
-  "caPool": "projects/${projectId}/locations/us-central1/caPools/capool-dep-2",
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "An updated TLS Inspection Policy to decrypt traffic",
-  "excludePublicCaSet": true,
-  "minTlsVersion": "TLS_1_2",
-  "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
-  "tlsFeatureProfile": "PROFILE_COMPATIBLE",
-  "updateTime": "2024-04-01T12:34:56.123456Z"
-}
-
----
-
-GRPC /google.cloud.networksecurity.v1.NetworkSecurity/GetTlsInspectionPolicy
-
-{
-  "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}"
-}
-
-OK
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
 
 {
   "caPool": "projects/${projectId}/locations/us-central1/caPools/capool-dep-2",
   "createTime": "2024-04-01T12:34:56.123456Z",
   "description": "An updated TLS Inspection Policy to decrypt traffic",
   "excludePublicCaSet": true,
-  "minTlsVersion": "TLS_1_2",
+  "minTlsVersion": 3,
   "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
-  "tlsFeatureProfile": "PROFILE_COMPATIBLE",
+  "tlsFeatureProfile": 1,
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }
 
 ---
 
-GRPC /google.cloud.networksecurity.v1.NetworkSecurity/DeleteTlsInspectionPolicy
+DELETE https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FtlsInspectionPolicies%2Ftlsinspection-${uniqueId}
 
-{
-  "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}"
-}
-
-OK
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
 
 {
   "metadata": {
@@ -219,13 +261,20 @@ OK
 
 ---
 
-GRPC /google.longrunning.Operations/GetOperation
+GET https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Foperations%2F${operationID}
 
-{
-  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
-}
-
-OK
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
 
 {
   "done": true,

--- a/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-basic/_identities.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-basic/_identities.yaml
@@ -1,9 +1,3 @@
-- caisURL: //privateca.googleapis.com/projects/${projectId}/locations/us-central1/caPools/capool-${uniqueId}
-  group: privateca.cnrm.cloud.google.com
-  kind: PrivateCACAPool
-  name: capool-${uniqueId}
-  namespace: ${uniqueId}
-  version: v1beta1
 - caisURL: //networksecurity.googleapis.com/projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}
   group: networksecurity.cnrm.cloud.google.com
   kind: NetworkSecurityTLSInspectionPolicy

--- a/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-basic/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-basic/create.yaml
@@ -9,7 +9,7 @@ spec:
   description: "A TLS Inspection Policy to decrypt traffic"
   caPoolRef:
     # Use external reference only. A CA pool with enabled CA is required.
-    # Once b/294109268 is fixed, we can support reference to a KCC managed CA pool.
+    # KCC does not support enabling a created CA.
     external: projects/${projectId}/locations/us-central1/caPools/capool-dep-1
   excludePublicCASet: true
   minTLSVersion: TLS_1_2

--- a/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-basic/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-basic/create.yaml
@@ -8,7 +8,9 @@ spec:
   location: us-central1
   description: "A TLS Inspection Policy to decrypt traffic"
   caPoolRef:
-    name: capool-${uniqueId}
+    # Use external reference only. A CA pool with enabled CA is required.
+    # Once b/294109268 is fixed, we can support reference to a KCC managed CA pool.
+    external: projects/${projectId}/locations/us-central1/caPools/capool-dep-1
   excludePublicCASet: true
   minTLSVersion: TLS_1_2
   tlsFeatureProfile: PROFILE_COMPATIBLE

--- a/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-basic/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-basic/dependencies.yaml
@@ -1,9 +1,0 @@
-apiVersion: privateca.cnrm.cloud.google.com/v1beta1
-kind: PrivateCACAPool
-metadata:
-  name: capool-${uniqueId}
-spec:
-  projectRef:
-    external: projects/${projectId}
-  location: us-central1
-  tier: DEVOPS

--- a/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-basic/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-basic/update.yaml
@@ -8,7 +8,9 @@ spec:
   location: us-central1
   description: "An updated TLS Inspection Policy to decrypt traffic"
   caPoolRef:
-    name: capool-${uniqueId}
+    # Use external reference only. A CA pool with enabled CA is required.
+    # Once b/294109268 is fixed, we can support reference to a KCC managed CA pool.
+    external: projects/${projectId}/locations/us-central1/caPools/capool-dep-2
   excludePublicCASet: true
   minTLSVersion: TLS_1_2
   tlsFeatureProfile: PROFILE_COMPATIBLE

--- a/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-full/_generated_object_tlsinspectionpolicy-full.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-full/_generated_object_tlsinspectionpolicy-full.golden.yaml
@@ -1,0 +1,38 @@
+apiVersion: networksecurity.cnrm.cloud.google.com/v1alpha1
+kind: NetworkSecurityTLSInspectionPolicy
+metadata:
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 2
+  labels:
+    cnrm-test: "true"
+  name: tlsinspection-${uniqueId}
+  namespace: ${uniqueId}
+spec:
+  caPoolRef:
+    external: projects/${projectId}/locations/us-central1/caPools/capool-dep-2
+  customTLSFeatures:
+  - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+  - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+  description: An updated TLS Inspection Policy to decrypt traffic
+  excludePublicCASet: true
+  location: us-central1
+  minTLSVersion: TLS_1_1
+  projectRef:
+    external: projects/${projectId}
+  tlsFeatureProfile: PROFILE_CUSTOM
+  trustConfigRef:
+    external: projects/${projectId}/locations/us-central1/trustConfigs/trustconfig-dep-2
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  externalRef: projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}
+  observedGeneration: 2
+  observedState:
+    createTime: "1970-01-01T00:00:00Z"
+    updateTime: "1970-01-01T00:00:00Z"

--- a/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-full/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-full/_http.log
@@ -1,0 +1,323 @@
+GET https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FtlsInspectionPolicies%2Ftlsinspection-${uniqueId}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "message": "Resource 'projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}' was not found",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/tlsInspectionPolicies?%24alt=json%3Benum-encoding%3Dint&tlsInspectionPolicyId=tlsinspection-${uniqueId}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1
+
+{
+  "caPool": "projects/${projectId}/locations/us-central1/caPools/capool-dep-1",
+  "description": "A TLS Inspection Policy to decrypt traffic",
+  "excludePublicCaSet": true,
+  "minTlsVersion": 3,
+  "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
+  "tlsFeatureProfile": 1,
+  "trustConfig": "projects/${projectId}/locations/us-central1/trustConfigs/trustconfig-dep-1"
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": false,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.networksecurity.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
+    "target": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
+    "verb": "create"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
+}
+
+---
+
+GET https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Foperations%2F${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.networksecurity.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
+    "target": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
+    "verb": "create"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.networksecurity.v1.TlsInspectionPolicy",
+    "caPool": "projects/${projectId}/locations/us-central1/caPools/capool-dep-1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "description": "A TLS Inspection Policy to decrypt traffic",
+    "excludePublicCaSet": true,
+    "minTlsVersion": "TLS_1_2",
+    "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
+    "tlsFeatureProfile": "PROFILE_COMPATIBLE",
+    "trustConfig": "projects/${projectId}/locations/us-central1/trustConfigs/trustconfig-dep-1",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GET https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FtlsInspectionPolicies%2Ftlsinspection-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "caPool": "projects/${projectId}/locations/us-central1/caPools/capool-dep-1",
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "customTlsFeatures": [],
+  "description": "A TLS Inspection Policy to decrypt traffic",
+  "excludePublicCaSet": true,
+  "minTlsVersion": 3,
+  "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
+  "tlsFeatureProfile": 1,
+  "trustConfig": "projects/${projectId}/locations/us-central1/trustConfigs/trustconfig-dep-1",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+PATCH https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}?%24alt=json%3Benum-encoding%3Dint&updateMask=caPool%2CcustomTlsFeatures%2Cdescription%2CminTlsVersion%2CtlsFeatureProfile%2CtrustConfig
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: tls_inspection_policy.name=projects%2F${projectId}%2Flocations%2Fus-central1%2FtlsInspectionPolicies%2Ftlsinspection-${uniqueId}
+
+{
+  "caPool": "projects/${projectId}/locations/us-central1/caPools/capool-dep-2",
+  "customTlsFeatures": [
+    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+  ],
+  "description": "An updated TLS Inspection Policy to decrypt traffic",
+  "excludePublicCaSet": true,
+  "minTlsVersion": 2,
+  "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
+  "tlsFeatureProfile": 4,
+  "trustConfig": "projects/${projectId}/locations/us-central1/trustConfigs/trustconfig-dep-2"
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": false,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.networksecurity.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
+    "target": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
+    "verb": "update"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
+}
+
+---
+
+GET https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Foperations%2F${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.networksecurity.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
+    "target": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
+    "verb": "update"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.networksecurity.v1.TlsInspectionPolicy",
+    "caPool": "projects/${projectId}/locations/us-central1/caPools/capool-dep-2",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "customTlsFeatures": [
+      "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+      "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+    ],
+    "description": "An updated TLS Inspection Policy to decrypt traffic",
+    "excludePublicCaSet": true,
+    "minTlsVersion": "TLS_1_1",
+    "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
+    "tlsFeatureProfile": "PROFILE_CUSTOM",
+    "trustConfig": "projects/${projectId}/locations/us-central1/trustConfigs/trustconfig-dep-2",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GET https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FtlsInspectionPolicies%2Ftlsinspection-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "caPool": "projects/${projectId}/locations/us-central1/caPools/capool-dep-2",
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "customTlsFeatures": [
+    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+  ],
+  "description": "An updated TLS Inspection Policy to decrypt traffic",
+  "excludePublicCaSet": true,
+  "minTlsVersion": 2,
+  "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
+  "tlsFeatureProfile": 4,
+  "trustConfig": "projects/${projectId}/locations/us-central1/trustConfigs/trustconfig-dep-2",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+DELETE https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FtlsInspectionPolicies%2Ftlsinspection-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": false,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.networksecurity.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
+    "target": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
+    "verb": "delete"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
+}
+
+---
+
+GET https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Foperations%2F${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.networksecurity.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
+    "target": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
+    "verb": "delete"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.protobuf.Empty"
+  }
+}

--- a/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-full/_http_mock.log
+++ b/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-full/_http_mock.log
@@ -1,0 +1,323 @@
+GET https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FtlsInspectionPolicies%2Ftlsinspection-${uniqueId}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "message": "TlsInspectionPolicy \"projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}\" not found",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/tlsInspectionPolicies?%24alt=json%3Benum-encoding%3Dint&tlsInspectionPolicyId=tlsinspection-${uniqueId}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1
+
+{
+  "caPool": "projects/${projectId}/locations/us-central1/caPools/capool-dep-1",
+  "description": "A TLS Inspection Policy to decrypt traffic",
+  "excludePublicCaSet": true,
+  "minTlsVersion": 3,
+  "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
+  "tlsFeatureProfile": 1,
+  "trustConfig": "projects/${projectId}/locations/us-central1/trustConfigs/trustconfig-dep-1"
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.networksecurity.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "target": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
+    "verb": "create"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
+}
+
+---
+
+GET https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Foperations%2F${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.networksecurity.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "target": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
+    "verb": "create"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.networksecurity.v1.TlsInspectionPolicy",
+    "caPool": "projects/${projectId}/locations/us-central1/caPools/capool-dep-1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "description": "A TLS Inspection Policy to decrypt traffic",
+    "excludePublicCaSet": true,
+    "minTlsVersion": "TLS_1_2",
+    "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
+    "tlsFeatureProfile": "PROFILE_COMPATIBLE",
+    "trustConfig": "projects/${projectId}/locations/us-central1/trustConfigs/trustconfig-dep-1",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GET https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FtlsInspectionPolicies%2Ftlsinspection-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "caPool": "projects/${projectId}/locations/us-central1/caPools/capool-dep-1",
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "A TLS Inspection Policy to decrypt traffic",
+  "excludePublicCaSet": true,
+  "minTlsVersion": 3,
+  "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
+  "tlsFeatureProfile": 1,
+  "trustConfig": "projects/${projectId}/locations/us-central1/trustConfigs/trustconfig-dep-1",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+PATCH https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}?%24alt=json%3Benum-encoding%3Dint&updateMask=caPool%2CcustomTlsFeatures%2Cdescription%2CminTlsVersion%2CtlsFeatureProfile%2CtrustConfig
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+X-Goog-Request-Params: tls_inspection_policy.name=projects%2F${projectId}%2Flocations%2Fus-central1%2FtlsInspectionPolicies%2Ftlsinspection-${uniqueId}
+
+{
+  "caPool": "projects/${projectId}/locations/us-central1/caPools/capool-dep-2",
+  "customTlsFeatures": [
+    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+  ],
+  "description": "An updated TLS Inspection Policy to decrypt traffic",
+  "excludePublicCaSet": true,
+  "minTlsVersion": 2,
+  "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
+  "tlsFeatureProfile": 4,
+  "trustConfig": "projects/${projectId}/locations/us-central1/trustConfigs/trustconfig-dep-2"
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.networksecurity.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "target": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
+    "verb": "update"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
+}
+
+---
+
+GET https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Foperations%2F${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.networksecurity.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "target": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
+    "verb": "update"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.networksecurity.v1.TlsInspectionPolicy",
+    "caPool": "projects/${projectId}/locations/us-central1/caPools/capool-dep-2",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "customTlsFeatures": [
+      "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+      "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+    ],
+    "description": "An updated TLS Inspection Policy to decrypt traffic",
+    "excludePublicCaSet": true,
+    "minTlsVersion": "TLS_1_1",
+    "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
+    "tlsFeatureProfile": "PROFILE_CUSTOM",
+    "trustConfig": "projects/${projectId}/locations/us-central1/trustConfigs/trustconfig-dep-2",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GET https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FtlsInspectionPolicies%2Ftlsinspection-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "caPool": "projects/${projectId}/locations/us-central1/caPools/capool-dep-2",
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "customTlsFeatures": [
+    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+  ],
+  "description": "An updated TLS Inspection Policy to decrypt traffic",
+  "excludePublicCaSet": true,
+  "minTlsVersion": 2,
+  "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
+  "tlsFeatureProfile": 4,
+  "trustConfig": "projects/${projectId}/locations/us-central1/trustConfigs/trustconfig-dep-2",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+DELETE https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FtlsInspectionPolicies%2Ftlsinspection-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.networksecurity.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "target": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
+    "verb": "delete"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
+}
+
+---
+
+GET https://networksecurity.googleapis.com/v1/projects/${projectId}/locations/us-central1/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Foperations%2F${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.networksecurity.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "target": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
+    "verb": "delete"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.networksecurity.v1.TlsInspectionPolicy",
+    "caPool": "projects/${projectId}/locations/us-central1/caPools/capool-dep-2",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "customTlsFeatures": [
+      "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+      "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+    ],
+    "description": "An updated TLS Inspection Policy to decrypt traffic",
+    "excludePublicCaSet": true,
+    "minTlsVersion": "TLS_1_1",
+    "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
+    "tlsFeatureProfile": "PROFILE_CUSTOM",
+    "trustConfig": "projects/${projectId}/locations/us-central1/trustConfigs/trustconfig-dep-2",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}

--- a/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-full/_http_mock.log
+++ b/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-full/_http_mock.log
@@ -305,19 +305,6 @@ X-Xss-Protection: 0
   },
   "name": "projects/${projectId}/locations/us-central1/operations/${operationID}",
   "response": {
-    "@type": "type.googleapis.com/google.cloud.networksecurity.v1.TlsInspectionPolicy",
-    "caPool": "projects/${projectId}/locations/us-central1/caPools/capool-dep-2",
-    "createTime": "2024-04-01T12:34:56.123456Z",
-    "customTlsFeatures": [
-      "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
-      "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
-    ],
-    "description": "An updated TLS Inspection Policy to decrypt traffic",
-    "excludePublicCaSet": true,
-    "minTlsVersion": "TLS_1_1",
-    "name": "projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}",
-    "tlsFeatureProfile": "PROFILE_CUSTOM",
-    "trustConfig": "projects/${projectId}/locations/us-central1/trustConfigs/trustconfig-dep-2",
-    "updateTime": "2024-04-01T12:34:56.123456Z"
+    "@type": "type.googleapis.com/google.protobuf.Empty"
   }
 }

--- a/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-full/_identities.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-full/_identities.yaml
@@ -1,0 +1,6 @@
+- caisURL: //networksecurity.googleapis.com/projects/${projectId}/locations/us-central1/tlsInspectionPolicies/tlsinspection-${uniqueId}
+  group: networksecurity.cnrm.cloud.google.com
+  kind: NetworkSecurityTLSInspectionPolicy
+  name: tlsinspection-${uniqueId}
+  namespace: ${uniqueId}
+  version: v1alpha1

--- a/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-full/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-full/create.yaml
@@ -6,11 +6,14 @@ spec:
   projectRef:
     external: projects/${projectId}
   location: us-central1
-  description: "An updated TLS Inspection Policy to decrypt traffic"
+  description: "A TLS Inspection Policy to decrypt traffic"
   caPoolRef:
     # Use external reference only. A CA pool with enabled CA is required.
     # KCC does not support enabling a created CA.
-    external: projects/${projectId}/locations/us-central1/caPools/capool-dep-2
+    external: projects/${projectId}/locations/us-central1/caPools/capool-dep-1
+  trustConfigRef:
+    # Use external reference only until direct controller is implemented.
+    external: projects/${projectId}/locations/us-central1/trustConfigs/trustconfig-dep-1
   excludePublicCASet: true
   minTLSVersion: TLS_1_2
   tlsFeatureProfile: PROFILE_COMPATIBLE

--- a/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-full/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/networksecurity/v1alpha1/networksecuritytlsinspectionpolicy/tlsinspectionpolicy-full/update.yaml
@@ -11,6 +11,12 @@ spec:
     # Use external reference only. A CA pool with enabled CA is required.
     # KCC does not support enabling a created CA.
     external: projects/${projectId}/locations/us-central1/caPools/capool-dep-2
+  trustConfigRef:
+    # Use external reference only until direct controller is implemented.
+    external: projects/${projectId}/locations/us-central1/trustConfigs/trustconfig-dep-2
   excludePublicCASet: true
-  minTLSVersion: TLS_1_2
-  tlsFeatureProfile: PROFILE_COMPATIBLE
+  minTLSVersion: TLS_1_1
+  tlsFeatureProfile: PROFILE_CUSTOM
+  customTLSFeatures:
+  - "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA"
+  - "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"

--- a/tests/apichecks/testdata/exceptions/alpha-missingfields.txt
+++ b/tests/apichecks/testdata/exceptions/alpha-missingfields.txt
@@ -3250,8 +3250,6 @@
 [missing_field] crd=networksecuritypartnersserealms.networksecurity.cnrm.cloud.google.com version=v1alpha1: field ".spec.partnerNetwork" is not set in unstructured objects
 [missing_field] crd=networksecuritypartnersserealms.networksecurity.cnrm.cloud.google.com version=v1alpha1: field ".spec.partnerVPC" is not set in unstructured objects
 [missing_field] crd=networksecuritypartnersserealms.networksecurity.cnrm.cloud.google.com version=v1alpha1: field ".spec.projectRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=networksecuritytlsinspectionpolicies.networksecurity.cnrm.cloud.google.com version=v1alpha1: field ".spec.customTLSFeatures[]" is not set in unstructured objects
-[missing_field] crd=networksecuritytlsinspectionpolicies.networksecurity.cnrm.cloud.google.com version=v1alpha1: field ".spec.trustConfigRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=networkservicesauthzextensions.networkservices.cnrm.cloud.google.com version=v1alpha1: field ".spec.labels" is not set in unstructured objects
 [missing_field] crd=networkservicesedgecachekeysets.networkservices.cnrm.cloud.google.com version=v1alpha1: field ".spec.publicKey[].managed" is not set in unstructured objects
 [missing_field] crd=networkservicesedgecachekeysets.networkservices.cnrm.cloud.google.com version=v1alpha1: field ".spec.publicKey[].value.value" is not set in unstructured objects


### PR DESCRIPTION
### BRIEF Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Addresses #6787 

1. Updated NSTlsInspectionPolicy test cases, re-gen logs against real and mockGCP
2. Added a mapper function manually and commented out the generated mapper, removed the prefix of the resolved "CAPoolRef", to satisfy the GCP API restriction.


#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
