### PR TITLE
skills: prefer GAPIC go-client over raw pb gRPC client in direct implementer skills

### DIFF
--- a/.gemini/skills/kcc-direct-controller-implementer/SKILL.md
+++ b/.gemini/skills/kcc-direct-controller-implementer/SKILL.md
@@ -32,15 +32,24 @@ This skill guides the implementation of the controller, mappers, and fuzzer for 
       }
       ```
     - **Identity Parent Paths**: Create a `ParentString()` method on the resource's identity type (e.g., `KMSCryptoKeyIdentity`) instead of constructing formatting string patterns manually inside the controller. This keeps parent paths canonical and reusable.
-    - **Client Creation Options**: Do NOT build the authenticated HTTP client manually. Instead, retrieve configuration options using `RESTClientOptions()` and construct the REST client:
-      ```go
-      var opts []option.ClientOption
-      opts, err := m.config.RESTClientOptions()
-      if err != nil {
-          return nil, err
-      }
-      gcpClient, err := gcp.NewConfigRESTClient(ctx, opts...)
-      ```
+    - **Client Creation Options & Go Client Preference**:
+      * **Prefer Official Go Client Libraries (`go-client`)**: When building the GCP client in `m.client(ctx)`, ALWAYS prefer using the official Google Cloud Go client library (GAPIC client, e.g., `cloud.google.com/go/<service>/apivX`, or discovery client `google.golang.org/api/...`) over raw protobuf gRPC client interfaces (`pb.FooClient` in `apivX/foopb` dialed with raw `grpc.Dial`).
+      * Why: GAPIC Go clients (`*service.FooClient` or `*service.FooRESTClient`) automatically handle authentication, OAuth scopes, retry logic, and wrap Long-Running Operations (LROs) into clean operation structs (`*service.FooOperation`), avoiding authentication errors and manual LRO polling.
+      * **Client Construction Example**: Retrieve configuration options using `m.config.RESTClientOptions()` (when constructing a REST client variant, e.g., `NewFooRESTClient`) or `m.config.GRPCClientOptions()` (when constructing a gRPC client variant, e.g., `NewFooClient`):
+        ```go
+        var opts []option.ClientOption
+        opts, err := m.config.RESTClientOptions() // or m.config.GRPCClientOptions() for gRPC variant
+        if err != nil {
+            return nil, err
+        }
+        // Prefer GAPIC Go client constructors over manual grpc.Dial with pb clients
+        gcpClient, err := gcp.NewMyResourceRESTClient(ctx, opts...) // or gcp.NewMyResourceClient(ctx, opts...)
+        if err != nil {
+            return nil, fmt.Errorf("building MyResource client: %w", err)
+        }
+        ```
+      * **Protobuf Fallback (`pb.`)**: Only fall back to raw protobuf gRPC clients (`pb.NewFooClient(conn)` with `grpc.Dial`) if a GAPIC Go client library struct/constructor does not exist for the API.
+      * **Try Different Client Variants on Issues During Testing**: When testing the controller (e.g. running `./hack/record-gcp` or API checks) and you face authentication issues, 403/404/500 errors, or connection problems, **try switching to the different client variant**. If `NewFooClient` (gRPC) fails or has auth/LRO issues, try switching to `NewFooRESTClient` (REST) with `RESTClientOptions()`, or vice versa. Some GCP endpoints/services only support REST or have issues with gRPC authentication.
     - **Diff Comparison & Structured Diff (`tags.DiffForTopLevelFields`)**: Always prefer using top-level field tags-based diff comparison via `tags.DiffForTopLevelFields` over recursive/magical comparison functions (such as `common.CompareProtoMessageStructuredDiff` or `common.CompareProtoMessage` which are deprecated/discouraged due to unpredictable behaviors in `BasicDiff`).
       ```go
       func compareResource(ctx context.Context, actual, desired *pb.MyResource) (*structuredreporting.Diff, *fieldmaskpb.FieldMask, error) {

--- a/.gemini/skills/kcc-direct-controller-implementer/SKILL.md
+++ b/.gemini/skills/kcc-direct-controller-implementer/SKILL.md
@@ -33,23 +33,26 @@ This skill guides the implementation of the controller, mappers, and fuzzer for 
       ```
     - **Identity Parent Paths**: Create a `ParentString()` method on the resource's identity type (e.g., `KMSCryptoKeyIdentity`) instead of constructing formatting string patterns manually inside the controller. This keeps parent paths canonical and reusable.
     - **Client Creation Options & Go Client Preference**:
-      * **Prefer Official Go Client Libraries (`go-client`)**: When building the GCP client in `m.client(ctx)`, ALWAYS prefer using the official Google Cloud Go client library (GAPIC client, e.g., `cloud.google.com/go/<service>/apivX`, or discovery client `google.golang.org/api/...`) over raw protobuf gRPC client interfaces (`pb.FooClient` in `apivX/foopb` dialed with raw `grpc.Dial`).
-      * Why: GAPIC Go clients (`*service.FooClient` or `*service.FooRESTClient`) automatically handle authentication, OAuth scopes, retry logic, and wrap Long-Running Operations (LROs) into clean operation structs (`*service.FooOperation`), avoiding authentication errors and manual LRO polling.
-      * **Client Construction Example**: Retrieve configuration options using `m.config.RESTClientOptions()` (when constructing a REST client variant, e.g., `NewFooRESTClient`) or `m.config.GRPCClientOptions()` (when constructing a gRPC client variant, e.g., `NewFooClient`):
+      * **Prefer GAPIC REST Client over gRPC (`go-client`)**: When building the GCP client in `m.client(ctx)`, ALWAYS prefer using the official Google Cloud Go client library (GAPIC client, e.g., `cloud.google.com/go/<service>/apivX`, or discovery client `google.golang.org/api/...`). Many GAPIC libraries provide both REST (`NewFooRESTClient`) and gRPC (`NewFooClient`) constructors. **You MUST prefer the REST variant (`NewFooRESTClient`)** initialized with `m.config.RESTClientOptions()`.
+      * Why: REST GAPIC clients integrate cleanly with HTTP golden traffic recording (`_http.log`), mock layer HTTP alignment, and avoid gRPC transport/auth quirks, while still automatically wrapping Long-Running Operations (`*service.FooOperation`), OAuth scopes, and retry logic.
+      * **Client Construction Example (GAPIC REST Primary Choice)**: Retrieve configuration options using `m.config.RESTClientOptions()` and construct the REST client:
         ```go
         var opts []option.ClientOption
-        opts, err := m.config.RESTClientOptions() // or m.config.GRPCClientOptions() for gRPC variant
+        opts, err := m.config.RESTClientOptions()
         if err != nil {
             return nil, err
         }
-        // Prefer GAPIC Go client constructors over manual grpc.Dial with pb clients
-        gcpClient, err := gcp.NewMyResourceRESTClient(ctx, opts...) // or gcp.NewMyResourceClient(ctx, opts...)
+        // Always prefer GAPIC New*RESTClient over New*Client (gRPC) or raw pb clients
+        gcpClient, err := gcp.NewMyResourceRESTClient(ctx, opts...)
         if err != nil {
-            return nil, fmt.Errorf("building MyResource client: %w", err)
+            return nil, fmt.Errorf("building MyResource REST client: %w", err)
         }
         ```
-      * **Protobuf Fallback (`pb.`)**: Only fall back to raw protobuf gRPC clients (`pb.NewFooClient(conn)` with `grpc.Dial`) if a GAPIC Go client library struct/constructor does not exist for the API.
-      * **Try Different Client Variants on Issues During Testing**: When testing the controller (e.g. running `./hack/record-gcp` or API checks) and you face authentication issues, 403/404/500 errors, or connection problems, **try switching to the different client variant**. If `NewFooClient` (gRPC) fails or has auth/LRO issues, try switching to `NewFooRESTClient` (REST) with `RESTClientOptions()`, or vice versa. Some GCP endpoints/services only support REST or have issues with gRPC authentication.
+      * **Fallback Order & Troubleshooting**:
+        1. **GAPIC REST Client (`NewFooRESTClient`)**: Primary preference.
+        2. **GAPIC gRPC Client (`NewFooClient`)**: Try with `m.config.GRPCClientOptions()` if the REST constructor is missing or fails during live GCP testing.
+        3. **Raw Protobuf gRPC (`pb.NewFooClient(conn)`)**: Only fall back to dialing raw gRPC conns (`grpc.Dial`) if no GAPIC Go client library struct/constructor exists for the API.
+      * **Try Different Client Variants on Issues During Testing**: When testing against real GCP (`./hack/record-gcp` or API checks) and encountering `403 Forbidden`, `404 Not Found`, or LRO polling errors, actively switch between the client variants (REST vs gRPC) to find the working transport.
     - **Diff Comparison & Structured Diff (`tags.DiffForTopLevelFields`)**: Always prefer using top-level field tags-based diff comparison via `tags.DiffForTopLevelFields` over recursive/magical comparison functions (such as `common.CompareProtoMessageStructuredDiff` or `common.CompareProtoMessage` which are deprecated/discouraged due to unpredictable behaviors in `BasicDiff`).
       ```go
       func compareResource(ctx context.Context, actual, desired *pb.MyResource) (*structuredreporting.Diff, *fieldmaskpb.FieldMask, error) {

--- a/.gemini/skills/kcc-direct-controller-logic-greenfield-implementer/SKILL.md
+++ b/.gemini/skills/kcc-direct-controller-logic-greenfield-implementer/SKILL.md
@@ -32,15 +32,24 @@ The direct controller must be implemented to manage reconciliation logic (Adapte
       }
       ```
     - **Identity Parent Paths**: Create a `ParentString()` method on the resource's identity type (e.g., `KMSCryptoKeyIdentity`) instead of constructing formatting string patterns manually inside the controller. This keeps parent paths canonical and reusable.
-    - **Client Creation Options**: Do NOT build the authenticated HTTP client manually. Instead, retrieve configuration options using `RESTClientOptions()` and construct the REST client:
-      ```go
-      var opts []option.ClientOption
-      opts, err := m.config.RESTClientOptions()
-      if err != nil {
-          return nil, err
-      }
-      gcpClient, err := gcp.NewConfigRESTClient(ctx, opts...)
-      ```
+    - **Client Creation Options & Go Client Preference**:
+      * **Prefer Official Go Client Libraries (`go-client`)**: When building the GCP client in `m.client(ctx)`, ALWAYS prefer using the official Google Cloud Go client library (GAPIC client, e.g., `cloud.google.com/go/<service>/apivX`, or discovery client `google.golang.org/api/...`) over raw protobuf gRPC client interfaces (`pb.FooClient` in `apivX/foopb` dialed with raw `grpc.Dial`).
+      * Why: GAPIC Go clients (`*service.FooClient` or `*service.FooRESTClient`) automatically handle authentication, OAuth scopes, retry logic, and wrap Long-Running Operations (LROs) into clean operation structs (`*service.FooOperation`), avoiding authentication errors and manual LRO polling.
+      * **Client Construction Example**: Retrieve configuration options using `m.config.RESTClientOptions()` (when constructing a REST client variant, e.g., `NewFooRESTClient`) or `m.config.GRPCClientOptions()` (when constructing a gRPC client variant, e.g., `NewFooClient`):
+        ```go
+        var opts []option.ClientOption
+        opts, err := m.config.RESTClientOptions() // or m.config.GRPCClientOptions() for gRPC variant
+        if err != nil {
+            return nil, err
+        }
+        // Prefer GAPIC Go client constructors over manual grpc.Dial with pb clients
+        gcpClient, err := gcp.NewMyResourceRESTClient(ctx, opts...) // or gcp.NewMyResourceClient(ctx, opts...)
+        if err != nil {
+            return nil, fmt.Errorf("building MyResource client: %w", err)
+        }
+        ```
+      * **Protobuf Fallback (`pb.`)**: Only fall back to raw protobuf gRPC clients (`pb.NewFooClient(conn)` with `grpc.Dial`) if a GAPIC Go client library struct/constructor does not exist for the API.
+      * **Try Different Client Variants on Issues During Testing**: When testing the controller (e.g. running `./hack/record-gcp` or API checks) and you face authentication issues, 403/404/500 errors, or connection problems, **try switching to the different client variant**. If `NewFooClient` (gRPC) fails or has auth/LRO issues, try switching to `NewFooRESTClient` (REST) with `RESTClientOptions()`, or vice versa. Some GCP endpoints/services only support REST or have issues with gRPC authentication.
     - **Diff Comparison & Structured Diff (`tags.DiffForTopLevelFields`)**: Always prefer using top-level field tags-based diff comparison via `tags.DiffForTopLevelFields` over recursive/magical comparison functions (such as `common.CompareProtoMessageStructuredDiff` or `common.CompareProtoMessage` which are deprecated/discouraged due to unpredictable behaviors in `BasicDiff`).
       ```go
       func compareResource(ctx context.Context, actual, desired *pb.MyResource) (*structuredreporting.Diff, *fieldmaskpb.FieldMask, error) {

--- a/.gemini/skills/kcc-direct-controller-logic-greenfield-implementer/SKILL.md
+++ b/.gemini/skills/kcc-direct-controller-logic-greenfield-implementer/SKILL.md
@@ -33,23 +33,26 @@ The direct controller must be implemented to manage reconciliation logic (Adapte
       ```
     - **Identity Parent Paths**: Create a `ParentString()` method on the resource's identity type (e.g., `KMSCryptoKeyIdentity`) instead of constructing formatting string patterns manually inside the controller. This keeps parent paths canonical and reusable.
     - **Client Creation Options & Go Client Preference**:
-      * **Prefer Official Go Client Libraries (`go-client`)**: When building the GCP client in `m.client(ctx)`, ALWAYS prefer using the official Google Cloud Go client library (GAPIC client, e.g., `cloud.google.com/go/<service>/apivX`, or discovery client `google.golang.org/api/...`) over raw protobuf gRPC client interfaces (`pb.FooClient` in `apivX/foopb` dialed with raw `grpc.Dial`).
-      * Why: GAPIC Go clients (`*service.FooClient` or `*service.FooRESTClient`) automatically handle authentication, OAuth scopes, retry logic, and wrap Long-Running Operations (LROs) into clean operation structs (`*service.FooOperation`), avoiding authentication errors and manual LRO polling.
-      * **Client Construction Example**: Retrieve configuration options using `m.config.RESTClientOptions()` (when constructing a REST client variant, e.g., `NewFooRESTClient`) or `m.config.GRPCClientOptions()` (when constructing a gRPC client variant, e.g., `NewFooClient`):
+      * **Prefer GAPIC REST Client over gRPC (`go-client`)**: When building the GCP client in `m.client(ctx)`, ALWAYS prefer using the official Google Cloud Go client library (GAPIC client, e.g., `cloud.google.com/go/<service>/apivX`, or discovery client `google.golang.org/api/...`). Many GAPIC libraries provide both REST (`NewFooRESTClient`) and gRPC (`NewFooClient`) constructors. **You MUST prefer the REST variant (`NewFooRESTClient`)** initialized with `m.config.RESTClientOptions()`.
+      * Why: REST GAPIC clients integrate cleanly with HTTP golden traffic recording (`_http.log`), mock layer HTTP alignment, and avoid gRPC transport/auth quirks, while still automatically wrapping Long-Running Operations (`*service.FooOperation`), OAuth scopes, and retry logic.
+      * **Client Construction Example (GAPIC REST Primary Choice)**: Retrieve configuration options using `m.config.RESTClientOptions()` and construct the REST client:
         ```go
         var opts []option.ClientOption
-        opts, err := m.config.RESTClientOptions() // or m.config.GRPCClientOptions() for gRPC variant
+        opts, err := m.config.RESTClientOptions()
         if err != nil {
             return nil, err
         }
-        // Prefer GAPIC Go client constructors over manual grpc.Dial with pb clients
-        gcpClient, err := gcp.NewMyResourceRESTClient(ctx, opts...) // or gcp.NewMyResourceClient(ctx, opts...)
+        // Always prefer GAPIC New*RESTClient over New*Client (gRPC) or raw pb clients
+        gcpClient, err := gcp.NewMyResourceRESTClient(ctx, opts...)
         if err != nil {
-            return nil, fmt.Errorf("building MyResource client: %w", err)
+            return nil, fmt.Errorf("building MyResource REST client: %w", err)
         }
         ```
-      * **Protobuf Fallback (`pb.`)**: Only fall back to raw protobuf gRPC clients (`pb.NewFooClient(conn)` with `grpc.Dial`) if a GAPIC Go client library struct/constructor does not exist for the API.
-      * **Try Different Client Variants on Issues During Testing**: When testing the controller (e.g. running `./hack/record-gcp` or API checks) and you face authentication issues, 403/404/500 errors, or connection problems, **try switching to the different client variant**. If `NewFooClient` (gRPC) fails or has auth/LRO issues, try switching to `NewFooRESTClient` (REST) with `RESTClientOptions()`, or vice versa. Some GCP endpoints/services only support REST or have issues with gRPC authentication.
+      * **Fallback Order & Troubleshooting**:
+        1. **GAPIC REST Client (`NewFooRESTClient`)**: Primary preference.
+        2. **GAPIC gRPC Client (`NewFooClient`)**: Try with `m.config.GRPCClientOptions()` if the REST constructor is missing or fails during live GCP testing.
+        3. **Raw Protobuf gRPC (`pb.NewFooClient(conn)`)**: Only fall back to dialing raw gRPC conns (`grpc.Dial`) if no GAPIC Go client library struct/constructor exists for the API.
+      * **Try Different Client Variants on Issues During Testing**: When testing against real GCP (`./hack/record-gcp` or API checks) and encountering `403 Forbidden`, `404 Not Found`, or LRO polling errors, actively switch between the client variants (REST vs gRPC) to find the working transport.
     - **Diff Comparison & Structured Diff (`tags.DiffForTopLevelFields`)**: Always prefer using top-level field tags-based diff comparison via `tags.DiffForTopLevelFields` over recursive/magical comparison functions (such as `common.CompareProtoMessageStructuredDiff` or `common.CompareProtoMessage` which are deprecated/discouraged due to unpredictable behaviors in `BasicDiff`).
       ```go
       func compareResource(ctx context.Context, actual, desired *pb.MyResource) (*structuredreporting.Diff, *fieldmaskpb.FieldMask, error) {

--- a/.gemini/skills/reviewgen-greenfield-controller/SKILL.md
+++ b/.gemini/skills/reviewgen-greenfield-controller/SKILL.md
@@ -26,7 +26,8 @@ Please respect the following review criteria and invariants when reviewing.
 *   **Reference Example:** A good example of minimal and maximal test suites can be found here: [`gkehubscope`](https://github.com/GoogleCloudPlatform/k8s-config-connector/tree/d5ce0db71838fcb63ea99de8be8fd53fa90bf597/pkg/test/resourcefixture/testdata/basic/gkehub/v1alpha1/gkehubscope).
 *   Check for appropriate edge-case testing if any complex logic exists in the controller (e.g., dependencies on other resources, complex identity mapping).
 
-## 6. General Controller Structure
+## 6. General Controller Structure & Client Creation
+*   **Client Creation Preference**: Verify that the controller uses an official GAPIC Go client library (e.g., `cloud.google.com/go/<service>/apivX` via `NewFooClient` or `NewFooRESTClient`) instead of manually calling `grpc.Dial` with raw protobuf gRPC client interfaces (`pb.New...Client`), unless no Go client struct exists for the API.
 *   **Reference Implementation:** The canonical reference controller implementation is [`workerpool_controller.go`](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/d5ce0db71838fcb63ea99de8be8fd53fa90bf597/pkg/controller/direct/cloudbuild/workerpool_controller.go) (Note: it predates `IdentityV2` and does not handle it correctly, so ensure new controllers implement `IdentityV2` properly).
 *   The controller must implement the `directbase.Model` and `directbase.Adapter` interfaces.
 *   It should contain appropriate dependency resolution (`resolveDependencies`).
@@ -37,6 +38,7 @@ When proposing changes or stating LGTM, format the review description as follows
 ```markdown
 ### KCC Auto-Review Results
 * **Trigger criteria matched**: [Yes/No]
+* **Client Creation**: [Pass/Fail] - (List if raw pb/grpc.Dial is used instead of GAPIC go-client)
 * **Proto Diffs & Update Mask**: [Pass/Fail] - (List any issues with diff calculation)
 * **Structured Reporting**: [Pass/Fail] - (List if structured reporting is missing)
 * **KRM Status Updates**: [Pass/Fail] - (List if status update is skipped on no-op updates)

--- a/.gemini/skills/reviewgen-greenfield-controller/SKILL.md
+++ b/.gemini/skills/reviewgen-greenfield-controller/SKILL.md
@@ -27,7 +27,7 @@ Please respect the following review criteria and invariants when reviewing.
 *   Check for appropriate edge-case testing if any complex logic exists in the controller (e.g., dependencies on other resources, complex identity mapping).
 
 ## 6. General Controller Structure & Client Creation
-*   **Client Creation Preference**: Verify that the controller uses an official GAPIC Go client library (e.g., `cloud.google.com/go/<service>/apivX` via `NewFooClient` or `NewFooRESTClient`) instead of manually calling `grpc.Dial` with raw protobuf gRPC client interfaces (`pb.New...Client`), unless no Go client struct exists for the API.
+*   **Client Creation Preference**: Verify that the controller uses an official GAPIC Go client library REST constructor (e.g., `cloud.google.com/go/<service>/apivX` via `NewFooRESTClient`) instead of `NewFooClient` (gRPC) or manually calling `grpc.Dial` with raw protobuf client interfaces (`pb.New...Client`), unless REST is unavailable or fails.
 *   **Reference Implementation:** The canonical reference controller implementation is [`workerpool_controller.go`](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/d5ce0db71838fcb63ea99de8be8fd53fa90bf597/pkg/controller/direct/cloudbuild/workerpool_controller.go) (Note: it predates `IdentityV2` and does not handle it correctly, so ensure new controllers implement `IdentityV2` properly).
 *   The controller must implement the `directbase.Model` and `directbase.Adapter` interfaces.
 *   It should contain appropriate dependency resolution (`resolveDependencies`).


### PR DESCRIPTION
Updates Client Creation Options in kcc-direct-controller-logic-greenfield-implementer and kcc-direct-controller-implementer to explicitly instruct preferring official GAPIC Go client libraries over raw pb gRPC client interfaces with grpc.Dial, explains why grpc.Dial leads to auth and LRO issues, provides code examples using RESTClientOptions/GRPCClientOptions, and recommends trying alternative client variants on test or auth failures. Also updates reviewgen-greenfield-controller with verification criteria.

### reasoning from gemini

The previous instruction under **Client Creation Options** gave a hardcoded example using `gcp.NewConfigRESTClient(ctx, opts...)`. For most GCP services (like `networksecurity`), `NewConfigRESTClient` does not exist in the official GAPIC package. When an agent couldn't find `NewConfigRESTClient`, it looked at the protobuf subpackage (`apivX/foopb`), saw the raw gRPC client interface `pb.FooClient`, and wrote manual `grpc.Dial(...)` calls. Raw `grpc.Dial` calls lack GAPIC auth handling, scopes, and LRO wrappers (`*service.FooOperation`), leading to authentication issues and manual operation polling.

### Summary of Changes

1. **Updated Greenfield Controller Implementer Skill**: [kcc-direct-controller-logic-greenfield-implementer/SKILL.md](file:///usr/local/google/home/barni/workspace/src/github.com/barney-s/k8s-config-connector/.gemini/skills/kcc-direct-controller-logic-greenfield-implementer/SKILL.md#L35-L55)
   - **Prefer Official Go Client Libraries**: Clarified that agents MUST prefer using official Google Cloud Go SDK GAPIC clients (`*service.FooClient` or `*service.FooRESTClient` constructed with `NewFooClient` or `NewFooRESTClient`) or discovery API clients over raw `pb.` gRPC interfaces.
   - **Constructors with Config Options**: Provided code examples showing how to pass `m.config.RESTClientOptions()` (for REST variants) or `m.config.GRPCClientOptions()` (for gRPC variants) into official GAPIC Go client constructors.
   - **Protobuf Fallback**: Explicitly restricted raw protobuf gRPC clients (`pb.NewFooClient(conn)` with `grpc.Dial`) to only be used as a fallback when no Go client library struct exists for the API.
   - **Switching Variants on Testing / Auth Issues**: Added guidance instructing the agent that if it encounters authentication issues (403), 404s, or LRO problems when testing against real GCP (`hack/record-gcp`), it must try switching client variants (e.g. switching from `NewFooClient` to `NewFooRESTClient` with `RESTClientOptions()`, or vice versa).

2. **Updated General Direct Controller Implementer Skill**: [kcc-direct-controller-implementer/SKILL.md](file:///usr/local/google/home/barni/workspace/src/github.com/barney-s/k8s-config-connector/.gemini/skills/kcc-direct-controller-implementer/SKILL.md#L35-L55)
   - Synchronized the exact same **Client Creation Options & Go Client Preference** instructions so brownfield direct migrations also prefer official Go clients and troubleshoot by trying different client variants.

3. **Updated Greenfield Review Skill**: [reviewgen-greenfield-controller/SKILL.md](file:///usr/local/google/home/barni/workspace/src/github.com/barney-s/k8s-config-connector/.gemini/skills/reviewgen-greenfield-controller/SKILL.md#L30)
   - Added a verification point to **Section 6: General Controller Structure & Client Creation** and the **Review Comment Template** to flag PRs that manually call `grpc.Dial` with raw `pb.` interfaces when an official Go client exists.