### PR TITLE
Update review reminder workflow to send Google Chat messages

### DIFF
--- a/.github/workflows/review-reminder.yaml
+++ b/.github/workflows/review-reminder.yaml
@@ -36,22 +36,23 @@ jobs:
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           credentials_json: ${{ secrets.EMAIL_SA_KEY }}
-          access_token_scopes: 'https://www.googleapis.com/auth/gmail.send'
+          access_token_scopes: 'https://www.googleapis.com/auth/chat.bot'
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.11'
 
-      - name: Gather open PRs and send email via Gmail API
+      - name: Gather open PRs and send message via Google Chat API
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CHAT_SPACE: 'spaces/AAQADWDpVUw'
         run: |
           python3 -c '
-          import os, subprocess, json, urllib.request, email.message, base64
+          import os, subprocess, json, urllib.request
 
           team_users = ["acpana", "anfernee", "anhdle-sso", "barney-s", "gemmahou", "ldanielmadariaga", "maqiuyujoyce"]
-          email_sections = []
+          chat_sections = []
           has_prs = False
 
           for user in team_users:
@@ -59,43 +60,37 @@ jobs:
                   "gh", "pr", "list",
                   "--repo", "GoogleCloudPlatform/k8s-config-connector",
                   "--search", f"user-review-requested:{user} state:open",
-                  "--json", "url"
+                  "--json", "number,title,url"
               ]
               res = subprocess.run(cmd, capture_output=True, text=True)
               if res.returncode == 0:
                   prs = json.loads(res.stdout)
                   if prs:
                       has_prs = True
-                      urls = "\n".join(["* " + pr["url"] for pr in prs])
-                      email_sections.append(f"{user}:\n{urls}")
+                      items = "\n".join(["• <" + p["url"] + "|#" + str(p["number"]) + " " + p["title"] + ">" for p in prs])
+                      chat_sections.append(f"*{user}*:\n{items}")
 
           if not has_prs:
               print("No open PRs pending review for k8s-config-connector-team. Exiting.")
               exit(0)
 
-          body = "Hi k8s-config-connector-team,\n\nThis is a friendly reminder of open PRs that need your review:\n\n" + "\n\n".join(email_sections) + "\n"
-
-          msg = email.message.EmailMessage()
-          msg["Subject"] = "[Reminder] Open PRs requiring review for k8s-config-connector-team"
-          msg["From"] = "kcc-bot@google.com"
-          msg["To"] = "kcc-eng@google.com"
-          msg.set_content(body)
-
-          raw_msg = base64.urlsafe_b64encode(msg.as_bytes()).decode()
+          header = "🤖 *KCC PR Review Reminder*\n\nHi *k8s-config-connector-team*, here are the open PRs awaiting your review:\n\n"
+          body = header + "\n\n".join(chat_sections) + "\n"
 
           access_token = os.environ.get("CLOUDSDK_AUTH_ACCESS_TOKEN")
           if not access_token:
               print("CLOUDSDK_AUTH_ACCESS_TOKEN not found. Exiting.")
               exit(1)
 
+          space = os.environ.get("CHAT_SPACE", "spaces/AAQADWDpVUw")
           req = urllib.request.Request(
-              "https://gmail.googleapis.com/gmail/v1/users/me/messages/send",
-              data=json.dumps({"raw": raw_msg}).encode(),
+              f"https://chat.googleapis.com/v1/{space}/messages",
+              data=json.dumps({"text": body}).encode(),
               headers={
                   "Authorization": f"Bearer {access_token}",
                   "Content-Type": "application/json"
               }
           )
           with urllib.request.urlopen(req) as resp:
-              print("Email sent successfully via Gmail API. Response code:", resp.status)
+              print("Message sent successfully via Google Chat API. Response code:", resp.status)
           '


### PR DESCRIPTION
This PR updates the scheduled `.github/workflows/review-reminder.yaml` workflow to deliver twice-daily PR review reminders directly to Google Chat space `AAQADWDpVUw` via the Google Chat API (`https://www.googleapis.com/auth/chat.bot`).

### Changes
- Updated authentication scope from `https://www.googleapis.com/auth/gmail.send` to `https://www.googleapis.com/auth/chat.bot`.
- Formats review reminder digest with clickable links, PR numbers, and titles grouped by teammate.
- Sends messages directly to Google Chat via `POST https://chat.googleapis.com/v1/spaces/AAQADWDpVUw/messages`.