### PR TITLE
chore(ci): update review reminder schedule to Pacific business hours

### DIFF
--- a/.github/workflows/review-reminder.yaml
+++ b/.github/workflows/review-reminder.yaml
@@ -16,8 +16,8 @@ name: review-reminder
 
 on:
   schedule:
-    # Run twice daily at 9:00 AM and 2:00 PM UTC
-    - cron: '0 9,14 * * *'
+    # 9:00 AM & 1:00 PM PST / 10:00 AM & 2:00 PM PDT (Mon-Fri)
+    - cron: '0 17,21 * * 1-5'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Update the review reminder workflow cron schedule from `0 9,14 * * *` (which triggered at 2:00 AM and 7:00 AM PDT) to `0 17,21 * * 1-5`.

This ensures reminders trigger during business hours (Monday–Friday) across both PST and PDT:
- **Morning:** `17:00 UTC` -> **9:00 AM PST** / **10:00 AM PDT** (never before 9:00 AM Pacific)
- **Afternoon:** `21:00 UTC` -> **1:00 PM PST** / **2:00 PM PDT**