### PR TITLE
fix(ci): export access_token from google-github-actions/auth in review reminder

### DIFF
--- a/.github/workflows/review-reminder.yaml
+++ b/.github/workflows/review-reminder.yaml
@@ -32,10 +32,12 @@ jobs:
         with:
           ref: master
 
-      - name: Authenticate to GCP via Service Account Key
+      - id: auth
+        name: Authenticate to GCP via Service Account Key
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           credentials_json: ${{ secrets.EMAIL_SA_KEY }}
+          token_format: 'access_token'
           access_token_scopes: 'https://www.googleapis.com/auth/chat.bot'
 
       - name: Set up Python
@@ -47,6 +49,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CHAT_SPACE: 'spaces/AAQADWDpVUw'
+          CLOUDSDK_AUTH_ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
         run: |
           python3 -c '
           import os, subprocess, json, urllib.request


### PR DESCRIPTION
In `.github/workflows/review-reminder.yaml`, the Python step previously looked for `CLOUDSDK_AUTH_ACCESS_TOKEN` which was unset, causing:
```
CLOUDSDK_AUTH_ACCESS_TOKEN not found. Exiting.
```

This change:
1. Adds `id: auth` and `token_format: 'access_token'` to the `google-github-actions/auth` step.
2. Passes `CLOUDSDK_AUTH_ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}` to the Python step environment.