### PR TITLE
fix(logginglogmetric): escape "/" in metric ID when building the API path

### DIFF
--- a/pkg/controller/direct/logging/logginglogmetric_controller.go
+++ b/pkg/controller/direct/logging/logginglogmetric_controller.go
@@ -17,6 +17,7 @@ package logging
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"sort"
 	"strings"
 
@@ -308,8 +309,22 @@ func (a *logMetricAdapter) Export(ctx context.Context) (*unstructured.Unstructur
 	return un, nil
 }
 
+// fullyQualifiedName returns the metric resource name for use in API request
+// paths.
+//
+// A log metric ID may contain "/": Cloud Logging accepts it and Google's own
+// documentation suggests namespaced IDs such as "myapp/my_metric". The
+// generated client expands this name into the RFC 6570 reserved template
+// "v2/{+metricName}", and reserved expansion does not percent-encode "/". An
+// unescaped ID therefore becomes an extra path segment, the API answers 404,
+// Find() reads that as "not found", and the caller creates instead of
+// acquiring -- which then fails with 409 ALREADY_EXISTS.
+//
+// Only the ID is escaped; the "projects/{project}/metrics/" prefix stays path
+// structure. Create() is unaffected because it carries the name in the request
+// body, not in the path.
 func (a *logMetricAdapter) fullyQualifiedName() string {
-	return a.id.String()
+	return fmt.Sprintf("projects/%s/metrics/%s", a.id.Project, url.PathEscape(a.id.Metric))
 }
 
 func compareLogMetric(ctx context.Context, actual, desired *api.LogMetric, u *unstructured.Unstructured) (*structuredreporting.Diff, error) {

--- a/pkg/controller/direct/logging/logginglogmetric_controller_test.go
+++ b/pkg/controller/direct/logging/logginglogmetric_controller_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"testing"
+
+	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/logging/v1beta1"
+)
+
+func TestFullyQualifiedName(t *testing.T) {
+	grid := []struct {
+		name    string
+		project string
+		metric  string
+		want    string
+	}{
+		{
+			name:    "plain id is unchanged",
+			project: "my-project",
+			metric:  "my_metric",
+			want:    "projects/my-project/metrics/my_metric",
+		},
+		{
+			// Cloud Logging accepts "/" in a metric ID and Google's own
+			// documentation suggests namespaced IDs. The generated client
+			// expands the name with the reserved template "v2/{+metricName}",
+			// which leaves "/" alone, so an unescaped ID would add a path
+			// segment and the API would answer 404.
+			name:    "slash in id is escaped so it stays one path segment",
+			project: "my-project",
+			metric:  "myapp/my_metric",
+			want:    "projects/my-project/metrics/myapp%2Fmy_metric",
+		},
+		{
+			name:    "multiple slashes are all escaped",
+			project: "my-project",
+			metric:  "a/b/c",
+			want:    "projects/my-project/metrics/a%2Fb%2Fc",
+		},
+		{
+			// Characters that are legal in a path segment must not be
+			// mangled; over-escaping would break existing metrics.
+			name:    "dots, dashes and underscores are left alone",
+			project: "my-project",
+			metric:  "a.b-c_d",
+			want:    "projects/my-project/metrics/a.b-c_d",
+		},
+	}
+
+	for _, g := range grid {
+		t.Run(g.name, func(t *testing.T) {
+			a := &logMetricAdapter{
+				id: &krm.LoggingLogMetricIdentity{
+					Project: g.project,
+					Metric:  g.metric,
+				},
+			}
+			got := a.fullyQualifiedName()
+			if got != g.want {
+				t.Errorf("fullyQualifiedName() = %q, want %q", got, g.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this fixes

An existing `LoggingLogMetric` whose ID contains `/` can never be acquired. KCC always falls through to create and fails with `409 ALREADY_EXISTS`:

```
Update call failed: error creating: logMetric myapp/my_metric creation failed:
googleapi: Error 409: Metric myapp/my_metric already exists.
```

Cloud Logging accepts `/` in a metric ID, and Google's own documentation suggests namespaced IDs such as `myapp/my_metric`, so these are legal names.

## Root cause

`Find`, `Update` and `Delete` pass the resource name to the generated client, which expands it into the RFC 6570 **reserved** template `v2/{+metricName}`. Reserved expansion does not percent-encode `/`, so the ID turns into an extra path segment and the API answers 404.

Measured against a real project:

```
GET https://logging.googleapis.com/v2/projects/P/metrics/myapp%2Fmy_metric   -> 200  {"name": "myapp/my_metric", ...}
GET https://logging.googleapis.com/v2/projects/P/metrics/myapp/my_metric     -> 404
```

`Find` reads that 404 through `direct.IsNotFound` and returns `(false, nil)`, so the caller creates instead of acquiring.

`Create` is unaffected because it carries the name in the **request body** (`logMetric.Name`), not in the path. That asymmetry is why such a metric can be created by KCC but never adopted — and, once created, never deleted or updated either.

## The change

`fullyQualifiedName()` escapes only the metric ID; the `projects/{project}/metrics/` prefix stays path structure.

```go
-	return a.id.String()
+	return fmt.Sprintf("projects/%s/metrics/%s", a.id.Project, url.PathEscape(a.id.Metric))
```

## Tests

`TestFullyQualifiedName` covers four cases:

- plain ID is unchanged
- `/` is escaped so the ID stays one path segment
- multiple slashes are all escaped
- `.`, `-`, `_` are left alone — over-escaping would break metrics that work today

```
--- PASS: TestFullyQualifiedName (0.00s)
    --- PASS: TestFullyQualifiedName/plain_id_is_unchanged
    --- PASS: TestFullyQualifiedName/slash_in_id_is_escaped_so_it_stays_one_path_segment
    --- PASS: TestFullyQualifiedName/multiple_slashes_are_all_escaped
    --- PASS: TestFullyQualifiedName/dots,_dashes_and_underscores_are_left_alone
ok  	github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/logging	0.822s
```

I did not add a `mockgcp` case. Happy to add one if you would like the path covered end to end — I would appreciate a pointer on whether `mocklogging` should route the escaped or unescaped form.

## Related, not fixed here

`gcpurls.Template.Parse` has the same blind spot for `external` references. It splits on `/` and compares the segment count against the template's field count, so `projects/P/metrics/myapp/my_metric` yields 5 parts against 4 fields and does not match. That affects every resource whose last field may contain `/`, so it seemed better left to a separate change. Let me know if you would rather see them together.

## How this was found

Adopting an existing production project into Config Connector. Four log metrics were the only resources out of ~250 that could not be acquired.


---

*Reopened from #12499. That PR's branch ended up with a parentless commit after I amended in a `--depth 1` clone, which made the diff look like the whole tree and GitHub auto-closed it. Same change, rebased properly on `master` — 2 files, +93 −1.*
