### PR TITLE
Improve the brownfield migration status report and pipeline

### DIFF
--- a/.github/workflows/migration-tracker.yaml
+++ b/.github/workflows/migration-tracker.yaml
@@ -16,8 +16,8 @@ name: migration-tracker-bot
 
 on:
   schedule:
-    # Run daily at midnight UTC
-    - cron: '0 0 * * *'
+    # Run weekly every Sunday at 13:17 UTC (avoiding top-of-hour GitHub runner queues)
+    - cron: '17 13 * * 0'
   workflow_dispatch:
     # Allow manual triggering
 
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write  # Crucial to allow the bot to create PRs
+      pull-requests: write  # Crucial to allow the bot to create/update PRs
     steps:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -45,8 +45,7 @@ jobs:
 
       - name: Run migration tracker generator
         run: |
-          cd dev/migration-tracker
-          python3 generate_data.py
+          python3 dev/migration-tracker/generate_md.py 2>&1 | tee /tmp/generator_output.log
 
       - name: Commit and create Pull Request
         env:
@@ -55,30 +54,42 @@ jobs:
           git config --global user.name "GitHub Actions Bot"
           git config --global user.email "actions@github.com"
           
-          # Check if there are changes
-          if ! git diff --quiet dev/migration-tracker/data.json; then
-            echo "Changes detected in data.json. Creating Pull Request..."
+          # Check if there are changes in dev/migration-tracker/
+          if ! git diff --quiet dev/migration-tracker/; then
+            echo "Changes detected in migration tracker. Processing Pull Request..."
             
             BRANCH_NAME="automation/migration-tracker-update"
             git checkout -b $BRANCH_NAME
             
-            git add dev/migration-tracker/data.json
-            git commit -m "Update migration tracker data.json"
+            git add dev/migration-tracker/data.json dev/migration-tracker/MIGRATION_STATUS.md
+            git commit -m "Update migration tracker data.json and MIGRATION_STATUS.md"
             
-            # Push the branch to origin (force push to overwrite previous automation branches)
+            # Push the branch to origin (force push to overwrite previous automation branch)
             git push -f origin $BRANCH_NAME
             
-            # Check if a PR already exists for this branch to avoid duplicate errors
-            PR_EXISTS=$(gh pr list --head $BRANCH_NAME --json number --jq '.[0].number')
+            # Check if an open PR already exists for this branch
+            PR_EXISTS=$(gh pr list --head $BRANCH_NAME --state open --json number --jq '.[0].number')
             if [ -z "$PR_EXISTS" ]; then
-              gh pr create \
+              PR_EXISTS=$(gh pr create \
                 --title "Automatic Migration Tracker Update" \
-                --body "This is an automated daily PR to update the migration tracker data.json file with latest status of direct controllers." \
+                --body-file /tmp/generator_output.log \
                 --head $BRANCH_NAME \
-                --base master
+                --base master \
+                --reviewer "maqiuyujoyce" \
+                --jq '.number' \
+                --json number)
+              echo "Created Pull Request #$PR_EXISTS."
             else
-              echo "Pull Request #$PR_EXISTS already exists for $BRANCH_NAME. Skipping PR creation."
+              echo "Updated existing Pull Request #$PR_EXISTS with force-pushed changes."
+              gh pr edit $PR_EXISTS --body-file /tmp/generator_output.log --add-reviewer "maqiuyujoyce" || true
             fi
+
+            # Close any old/stale open PRs with title "Automatic Migration Tracker Update" that are not $PR_EXISTS
+            STALE_PRS=$(gh pr list --search "Automatic Migration Tracker Update in:title state:open" --json number --jq ".[].number | select(. != $PR_EXISTS)")
+            for pr in $STALE_PRS; do
+              echo "Closing stale PR #$pr in favor of #$PR_EXISTS..."
+              gh pr close "$pr" --comment "Closing in favor of updated weekly PR #$PR_EXISTS." || true
+            done
           else
-            echo "No changes detected in data.json."
+            echo "No changes detected in dev/migration-tracker/."
           fi

--- a/dev/migration-tracker/MIGRATION_STATUS.md
+++ b/dev/migration-tracker/MIGRATION_STATUS.md
@@ -1,0 +1,491 @@
+# KCC Brownfield Resource Migration Dashboard
+
+> [!NOTE]
+> For scope details, generator script usage, and tracking methodology, see [README.md](./README.md).
+
+## Migration Overview
+
+| Metric | Count | Percentage | Progress Bar |
+| :--- | :---: | :---: | :--- |
+| **Completed** | **10** | `4.7%` | `--------------------` |
+| **In Progress** | **165** | `77.5%` | `###############-----` |
+| &nbsp;&nbsp;&nbsp;&nbsp;-> *Direct Controller Enabled* | *71* | `33.3%` | `######--------------` |
+| **Not Started** | **38** | `17.8%` | `###-----------------` |
+| **Total Resources** | **213** | `100.0%` | |
+
+---
+
+## Step Implementation Status
+
+| Step Name | Description | Completed Resources | Progress |
+| :--- | :--- | :---: | :---: |
+| `gen-types` | Direct Go API Types in `apis/` | **145** / 213 | `68.1%` |
+| `identity-reference` | Identity and Ref logic (`*_identity.go` AND `*_reference.go`) | **123** / 213 | `57.7%` |
+| `mapper-fuzzer` | Proto/KRM Mappers AND Fuzzers in `pkg/controller/direct/` | **106** / 213 | `49.8%` |
+| `mocks` | MockGCP alignment and golden logs (`_http_mock.log`) | **148** / 213 | `69.5%` |
+| `controller` | Direct Controller implementation (`*_controller.go`, not all registered in static config) | **82** / 213 | `38.5%` |
+| `tests` | E2E migration test suite (`TestMigrationToDirect`) | **78** / 213 | `36.6%` |
+
+---
+
+## Top Priority Unmigrated Resources (Dependency Order)
+| Topo Order | Group | Kind | State | Types | Ref/ID | Controller | Downstream Count |
+| :---: | :--- | :--- | :---: | :---: | :---: | :---: | :---: |
+| #1 | `resourcemanager` | `Folder` | **In Progress** | Yes | Yes |  | `452` |
+| #2 | `resourcemanager` | `Project` | **In Progress** | Yes | Yes |  | `447` |
+| #3 | `kms` | `KMSKeyRing` | **In Progress** | Yes | Yes | Yes | `142` |
+| #4 | `kms` | `KMSCryptoKey` | **In Progress** | Yes | Yes | Yes | `140` |
+| #5 | `compute` | `ComputeNetwork` | **In Progress** | Yes | Yes | Yes | `136` |
+| #6 | `iam` | `IAMServiceAccount` | **In Progress** | Yes | Yes |  | `61` |
+| #7 | `storage` | `StorageBucket` | **In Progress** | Yes | Yes |  | `42` |
+| #8 | `compute` | `ComputeSubnetwork` | **In Progress** | Yes | Yes |  | `23` |
+| #9 | `serviceusage` | `Service` | **In Progress** | Yes | Yes | Yes | `15` |
+| #10 | `compute` | `ComputeSecurityPolicy` | **In Progress** | Yes | Yes | Yes | `13` |
+| #11 | `compute` | `ComputeHealthCheck` | **In Progress** | Yes |  |  | `12` |
+| #12 | `compute` | `ComputeHTTPHealthCheck` | **In Progress** | Yes | Yes | Yes | `11` |
+| #13 | `compute` | `ComputeNetworkEndpointGroup` | **In Progress** | Yes | Yes |  | `11` |
+| #14 | `compute` | `ComputeInstanceGroup` | **In Progress** | Yes | Yes | Yes | `10` |
+| #15 | `compute` | `ComputeBackendService` | **In Progress** | Yes | Yes |  | `9` |
+| #16 | `bigtable` | `BigtableInstance` | **In Progress** | Yes | Yes |  | `8` |
+| #17 | `pubsub` | `PubSubSchema` | **In Progress** | Yes | Yes | Yes | `8` |
+| #18 | `apigee` | `ApigeeOrganization` | **In Progress** | Yes | Yes |  | `7` |
+| #19 | `compute` | `ComputeBackendBucket` | **In Progress** | Yes |  |  | `7` |
+| #20 | `compute` | `ComputeInstanceTemplate` | **In Progress** |  |  |  | `7` |
+| #21 | `pubsub` | `PubSubTopic` | **In Progress** | Yes | Yes | Yes | `7` |
+| #22 | `compute` | `ComputeRouter` | **In Progress** | Yes | Yes | Yes | `6` |
+| #23 | `dataproc` | `DataprocCluster` | **In Progress** | Yes | Yes | Yes | `6` |
+| #24 | `compute` | `ComputeTargetVPNGateway` | **In Progress** | Yes |  |  | `5` |
+| #25 | `compute` | `ComputeURLMap` | **In Progress** | Yes | Yes | Yes | `5` |
+
+---
+## Resource Migration Progress by Service / Group
+
+<details>
+<summary>Click to expand progress by service / group</summary>
+
+| Group | Total | Completed | In Progress | Not Started | % Complete |
+| :--- | :---: | :---: | :---: | :---: | :---: |
+| `compute` | 56 | 1 | 52 | 3 | `1.8%` |
+| `iam` | 12 | 0 | 6 | 6 | `0.0%` |
+| `monitoring` | 9 | 1 | 8 | 0 | `11.1%` |
+| `networkservices` | 7 | 0 | 3 | 4 | `0.0%` |
+| `logging` | 5 | 1 | 4 | 0 | `20.0%` |
+| `accesscontextmanager` | 4 | 0 | 4 | 0 | `0.0%` |
+| `alloydb` | 4 | 1 | 3 | 0 | `25.0%` |
+| `bigquery` | 4 | 0 | 3 | 1 | `0.0%` |
+| `bigtable` | 4 | 0 | 4 | 0 | `0.0%` |
+| `certificatemanager` | 4 | 1 | 3 | 0 | `25.0%` |
+| `dlp` | 4 | 0 | 0 | 4 | `0.0%` |
+| `identityplatform` | 4 | 0 | 0 | 4 | `0.0%` |
+| `privateca` | 4 | 0 | 4 | 0 | `0.0%` |
+| `resourcemanager` | 4 | 0 | 2 | 2 | `0.0%` |
+| `sql` | 4 | 1 | 2 | 1 | `25.0%` |
+| `storage` | 4 | 0 | 3 | 1 | `0.0%` |
+| `tags` | 4 | 1 | 3 | 0 | `25.0%` |
+| `dataproc` | 3 | 0 | 3 | 0 | `0.0%` |
+| `dns` | 3 | 0 | 3 | 0 | `0.0%` |
+| `edgecontainer` | 3 | 0 | 2 | 1 | `0.0%` |
+| `gkehub` | 3 | 1 | 2 | 0 | `33.3%` |
+| `networksecurity` | 3 | 0 | 3 | 0 | `0.0%` |
+| `pubsub` | 3 | 0 | 3 | 0 | `0.0%` |
+| `servicedirectory` | 3 | 0 | 3 | 0 | `0.0%` |
+| `vertexai` | 3 | 0 | 2 | 1 | `0.0%` |
+| `apigee` | 2 | 0 | 2 | 0 | `0.0%` |
+| `binaryauthorization` | 2 | 0 | 0 | 2 | `0.0%` |
+| `cloudidentity` | 2 | 2 | 0 | 0 | `100.0%` |
+| `container` | 2 | 0 | 2 | 0 | `0.0%` |
+| `datacatalog` | 2 | 0 | 2 | 0 | `0.0%` |
+| `dataflow` | 2 | 0 | 2 | 0 | `0.0%` |
+| `edgenetwork` | 2 | 0 | 2 | 0 | `0.0%` |
+| `filestore` | 2 | 0 | 1 | 1 | `0.0%` |
+| `iap` | 2 | 0 | 1 | 1 | `0.0%` |
+| `kms` | 2 | 0 | 2 | 0 | `0.0%` |
+| `networkconnectivity` | 2 | 0 | 2 | 0 | `0.0%` |
+| `osconfig` | 2 | 0 | 2 | 0 | `0.0%` |
+| `run` | 2 | 0 | 2 | 0 | `0.0%` |
+| `secretmanager` | 2 | 0 | 2 | 0 | `0.0%` |
+| `serviceusage` | 2 | 0 | 2 | 0 | `0.0%` |
+| `spanner` | 2 | 0 | 2 | 0 | `0.0%` |
+| `artifactregistry` | 1 | 0 | 1 | 0 | `0.0%` |
+| `billingbudgets` | 1 | 0 | 1 | 0 | `0.0%` |
+| `cloudbuild` | 1 | 0 | 1 | 0 | `0.0%` |
+| `cloudfunctions` | 1 | 0 | 1 | 0 | `0.0%` |
+| `cloudids` | 1 | 0 | 1 | 0 | `0.0%` |
+| `cloudscheduler` | 1 | 0 | 0 | 1 | `0.0%` |
+| `configcontroller` | 1 | 0 | 0 | 1 | `0.0%` |
+| `containeranalysis` | 1 | 0 | 1 | 0 | `0.0%` |
+| `containerattached` | 1 | 0 | 1 | 0 | `0.0%` |
+| `datafusion` | 1 | 0 | 0 | 1 | `0.0%` |
+| `eventarc` | 1 | 0 | 0 | 1 | `0.0%` |
+| `firestore` | 1 | 0 | 1 | 0 | `0.0%` |
+| `memcache` | 1 | 0 | 1 | 0 | `0.0%` |
+| `pubsublite` | 1 | 0 | 1 | 0 | `0.0%` |
+| `recaptchaenterprise` | 1 | 0 | 1 | 0 | `0.0%` |
+| `redis` | 1 | 0 | 1 | 0 | `0.0%` |
+| `servicenetworking` | 1 | 0 | 1 | 0 | `0.0%` |
+| `sourcerepo` | 1 | 0 | 0 | 1 | `0.0%` |
+| `storagetransfer` | 1 | 0 | 0 | 1 | `0.0%` |
+| `vpcaccess` | 1 | 0 | 1 | 0 | `0.0%` |
+
+</details>
+
+---
+
+## Full Resource Migration Registry
+
+<details>
+<summary>Click to expand all resources</summary>
+
+| Group | Kind | Controller Type | State | Types | Identity/Ref | Mapper/Fuzz | Mocks | Controller | Tests | Direct Registered | Direct Defaulted |
+| :--- | :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| `accesscontextmanager` | `AccessContextManagerAccessLevel` | `Terraform` | **In Progress** | Yes | Yes |  |  |  |  |  |  |
+| `accesscontextmanager` | `AccessContextManagerAccessPolicy` | `Terraform` | **In Progress** | Yes | Yes |  |  |  |  |  |  |
+| `accesscontextmanager` | `AccessContextManagerServicePerimeter` | `Terraform` | **In Progress** | Yes | Yes |  |  |  |  |  |  |
+| `accesscontextmanager` | `AccessContextManagerServicePerimeterResource` | `Terraform` | **In Progress** | Yes |  |  |  |  |  |  |  |
+| `alloydb` | `AlloyDBBackup` | `Terraform` | **In Progress** | Yes | Yes |  |  |  |  |  |  |
+| `alloydb` | `AlloyDBCluster` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `alloydb` | `AlloyDBInstance` | `Direct` | **Completed** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| `alloydb` | `AlloyDBUser` | `Terraform` | **In Progress** | Yes | Yes |  | Yes |  |  |  |  |
+| `apigee` | `ApigeeEnvironment` | `DCL` | **In Progress** | Yes | Yes |  | Yes |  |  |  |  |
+| `apigee` | `ApigeeOrganization` | `DCL` | **In Progress** | Yes | Yes |  | Yes |  |  |  |  |
+| `artifactregistry` | `ArtifactRegistryRepository` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `bigquery` | `BigQueryDataset` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `bigquery` | `BigQueryJob` | `Terraform` | **Not Started** |  |  |  |  |  |  |  |  |
+| `bigquery` | `BigQueryRoutine` | `Terraform` | **In Progress** |  |  |  | Yes |  |  |  |  |
+| `bigquery` | `BigQueryTable` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `bigtable` | `BigtableAppProfile` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `bigtable` | `BigtableGCPolicy` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `bigtable` | `BigtableInstance` | `Terraform` | **In Progress** | Yes | Yes |  | Yes |  |  |  |  |
+| `bigtable` | `BigtableTable` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes |  |  |  |  |
+| `billingbudgets` | `BillingBudgetsBudget` | `DCL` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `binaryauthorization` | `BinaryAuthorizationAttestor` | `DCL` | **Not Started** |  |  |  |  |  |  |  |  |
+| `binaryauthorization` | `BinaryAuthorizationPolicy` | `DCL` | **Not Started** |  |  |  |  |  |  |  |  |
+| `certificatemanager` | `CertificateManagerCertificate` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `certificatemanager` | `CertificateManagerCertificateMap` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `certificatemanager` | `CertificateManagerCertificateMapEntry` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `certificatemanager` | `CertificateManagerDNSAuthorization` | `Direct` | **Completed** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| `cloudbuild` | `CloudBuildTrigger` | `Terraform` | **In Progress** | Yes | Yes |  |  |  |  |  |  |
+| `cloudfunctions` | `CloudFunctionsFunction` | `DCL` | **In Progress** |  |  |  | Yes |  |  |  |  |
+| `cloudidentity` | `CloudIdentityGroup` | `Direct` | **Completed** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| `cloudidentity` | `CloudIdentityMembership` | `Direct` | **Completed** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| `cloudids` | `CloudIDSEndpoint` | `Terraform` | **In Progress** |  |  |  | Yes |  |  |  |  |
+| `cloudscheduler` | `CloudSchedulerJob` | `DCL` | **Not Started** |  |  |  |  |  |  |  |  |
+| `compute` | `ComputeAddress` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `compute` | `ComputeBackendBucket` | `Terraform` | **In Progress** | Yes |  | Yes | Yes |  |  |  |  |
+| `compute` | `ComputeBackendService` | `Terraform` | **In Progress** | Yes | Yes |  | Yes |  |  |  |  |
+| `compute` | `ComputeDisk` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `compute` | `ComputeExternalVPNGateway` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `compute` | `ComputeFirewall` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `compute` | `ComputeFirewallPolicy` | `DCL` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `compute` | `ComputeFirewallPolicyAssociation` | `DCL` | **In Progress** | Yes |  | Yes |  |  |  |  |  |
+| `compute` | `ComputeFirewallPolicyRule` | `Direct` | **Completed** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| `compute` | `ComputeForwardingRule` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `compute` | `ComputeHTTPHealthCheck` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `compute` | `ComputeHTTPSHealthCheck` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `compute` | `ComputeHealthCheck` | `Terraform` | **In Progress** | Yes |  | Yes | Yes |  |  |  |  |
+| `compute` | `ComputeImage` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `compute` | `ComputeInstance` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `compute` | `ComputeInstanceGroup` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `compute` | `ComputeInstanceGroupManager` | `DCL` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `compute` | `ComputeInstanceTemplate` | `Terraform` | **In Progress** |  |  |  | Yes |  |  |  |  |
+| `compute` | `ComputeInterconnectAttachment` | `Terraform` | **In Progress** | Yes |  | Yes |  |  |  |  |  |
+| `compute` | `ComputeManagedSSLCertificate` | `Terraform` | **In Progress** |  |  |  | Yes |  |  |  |  |
+| `compute` | `ComputeNetwork` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `compute` | `ComputeNetworkEndpointGroup` | `Terraform` | **In Progress** | Yes | Yes | Yes |  |  |  |  |  |
+| `compute` | `ComputeNetworkFirewallPolicy` | `Terraform` | **In Progress** | Yes |  | Yes |  |  |  |  |  |
+| `compute` | `ComputeNetworkFirewallPolicyAssociation` | `Terraform` | **Not Started** |  |  |  |  |  |  |  |  |
+| `compute` | `ComputeNetworkPeering` | `Terraform` | **In Progress** | Yes |  | Yes |  |  |  |  |  |
+| `compute` | `ComputeNodeGroup` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes |  |  |  |  |
+| `compute` | `ComputeNodeTemplate` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `compute` | `ComputePacketMirroring` | `DCL` | **In Progress** | Yes |  | Yes |  |  |  |  |  |
+| `compute` | `ComputeProjectMetadata` | `Terraform` | **In Progress** | Yes |  | Yes |  |  |  |  |  |
+| `compute` | `ComputeRegionNetworkEndpointGroup` | `Terraform` | **In Progress** |  |  |  | Yes |  |  |  |  |
+| `compute` | `ComputeReservation` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `compute` | `ComputeResourcePolicy` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes |  |  |  |  |
+| `compute` | `ComputeRoute` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `compute` | `ComputeRouter` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `compute` | `ComputeRouterInterface` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `compute` | `ComputeRouterNAT` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `compute` | `ComputeRouterPeer` | `Terraform` | **Not Started** |  |  |  |  |  |  |  |  |
+| `compute` | `ComputeSSLCertificate` | `Terraform` | **In Progress** | Yes |  | Yes | Yes |  |  |  |  |
+| `compute` | `ComputeSSLPolicy` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `compute` | `ComputeSecurityPolicy` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `compute` | `ComputeServiceAttachment` | `DCL` | **In Progress** | Yes |  | Yes | Yes |  |  |  |  |
+| `compute` | `ComputeSharedVPCHostProject` | `Terraform` | **Not Started** |  |  |  |  |  |  |  |  |
+| `compute` | `ComputeSharedVPCServiceProject` | `Terraform` | **In Progress** | Yes |  |  |  |  |  |  |  |
+| `compute` | `ComputeSnapshot` | `Terraform` | **In Progress** | Yes | Yes | Yes |  |  |  |  |  |
+| `compute` | `ComputeSubnetwork` | `Terraform` | **In Progress** | Yes | Yes |  | Yes |  |  |  |  |
+| `compute` | `ComputeTargetGRPCProxy` | `Terraform` | **In Progress** | Yes |  | Yes | Yes |  |  |  |  |
+| `compute` | `ComputeTargetHTTPProxy` | `Terraform` | **In Progress** | Yes |  | Yes | Yes |  |  |  |  |
+| `compute` | `ComputeTargetHTTPSProxy` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `compute` | `ComputeTargetInstance` | `Terraform` | **In Progress** | Yes |  | Yes |  |  |  |  |  |
+| `compute` | `ComputeTargetPool` | `Terraform` | **In Progress** | Yes |  | Yes |  |  |  |  |  |
+| `compute` | `ComputeTargetSSLProxy` | `Terraform` | **In Progress** | Yes |  | Yes | Yes |  |  |  |  |
+| `compute` | `ComputeTargetTCPProxy` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `compute` | `ComputeTargetVPNGateway` | `Terraform` | **In Progress** | Yes |  |  | Yes |  |  |  |  |
+| `compute` | `ComputeURLMap` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `compute` | `ComputeVPNGateway` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes |  |  |  |  |
+| `compute` | `ComputeVPNTunnel` | `Terraform` | **In Progress** | Yes |  | Yes |  |  |  |  |  |
+| `configcontroller` | `ConfigControllerInstance` | `DCL` | **Not Started** |  |  |  |  |  |  |  |  |
+| `container` | `ContainerCluster` | `Terraform` | **In Progress** | Yes | Yes |  | Yes |  |  |  |  |
+| `container` | `ContainerNodePool` | `Terraform` | **In Progress** | Yes | Yes |  | Yes |  |  |  |  |
+| `containeranalysis` | `ContainerAnalysisNote` | `DCL` | **In Progress** |  |  |  | Yes |  |  |  |  |
+| `containerattached` | `ContainerAttachedCluster` | `Terraform` | **In Progress** | Yes |  |  | Yes |  |  |  |  |
+| `datacatalog` | `DataCatalogPolicyTag` | `Terraform` | **In Progress** | Yes | Yes |  |  |  |  |  |  |
+| `datacatalog` | `DataCatalogTaxonomy` | `Terraform` | **In Progress** | Yes | Yes | Yes |  |  |  |  |  |
+| `dataflow` | `DataflowFlexTemplateJob` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `dataflow` | `DataflowJob` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `datafusion` | `DataFusionInstance` | `DCL` | **Not Started** |  |  |  |  |  |  |  |  |
+| `dataproc` | `DataprocAutoscalingPolicy` | `DCL` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `dataproc` | `DataprocCluster` | `DCL` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `dataproc` | `DataprocWorkflowTemplate` | `DCL` | **In Progress** |  |  |  | Yes |  |  |  |  |
+| `dlp` | `DLPDeidentifyTemplate` | `DCL` | **Not Started** |  |  |  |  |  |  |  |  |
+| `dlp` | `DLPInspectTemplate` | `DCL` | **Not Started** |  |  |  |  |  |  |  |  |
+| `dlp` | `DLPJobTrigger` | `DCL` | **Not Started** |  |  |  |  |  |  |  |  |
+| `dlp` | `DLPStoredInfoType` | `DCL` | **Not Started** |  |  |  |  |  |  |  |  |
+| `dns` | `DNSManagedZone` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `dns` | `DNSPolicy` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `dns` | `DNSRecordSet` | `Terraform` | **In Progress** | Yes | Yes |  | Yes |  |  |  |  |
+| `edgecontainer` | `EdgeContainerCluster` | `Terraform` | **In Progress** |  |  |  | Yes |  |  |  |  |
+| `edgecontainer` | `EdgeContainerNodePool` | `Terraform` | **In Progress** |  |  |  | Yes |  |  |  |  |
+| `edgecontainer` | `EdgeContainerVpnConnection` | `Terraform` | **Not Started** |  |  |  |  |  |  |  |  |
+| `edgenetwork` | `EdgeNetworkNetwork` | `Terraform` | **In Progress** |  |  |  | Yes |  |  |  |  |
+| `edgenetwork` | `EdgeNetworkSubnet` | `Terraform` | **In Progress** |  |  |  | Yes |  |  |  |  |
+| `eventarc` | `EventarcTrigger` | `DCL` | **Not Started** |  |  |  |  |  |  |  |  |
+| `filestore` | `FilestoreBackup` | `DCL` | **Not Started** |  |  |  |  |  |  |  |  |
+| `filestore` | `FilestoreInstance` | `DCL` | **In Progress** | Yes | Yes |  | Yes |  |  |  |  |
+| `firestore` | `FirestoreIndex` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `gkehub` | `GKEHubFeature` | `DCL` | **In Progress** |  |  |  | Yes |  |  |  |  |
+| `gkehub` | `GKEHubFeatureMembership` | `Direct` | **Completed** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| `gkehub` | `GKEHubMembership` | `DCL` | **In Progress** |  |  |  | Yes |  |  |  |  |
+| `iam` | `IAMAccessBoundaryPolicy` | `Terraform` | **Not Started** |  |  |  |  |  |  |  |  |
+| `iam` | `IAMAuditConfig` | `IAMAuditConfig` | **In Progress** | Yes |  |  |  |  |  |  |  |
+| `iam` | `IAMCustomRole` | `Terraform` | **Not Started** |  |  |  |  |  |  |  |  |
+| `iam` | `IAMPartialPolicy` | `IAMPartialPolicy` | **In Progress** | Yes | Yes | Yes |  | Yes |  | Yes |  |
+| `iam` | `IAMPolicy` | `IAMPolicy` | **In Progress** | Yes | Yes | Yes |  | Yes |  |  |  |
+| `iam` | `IAMPolicyMember` | `IAMPolicyMember` | **In Progress** | Yes |  |  | Yes |  |  |  |  |
+| `iam` | `IAMServiceAccount` | `Terraform` | **In Progress** | Yes | Yes |  | Yes |  |  |  |  |
+| `iam` | `IAMServiceAccountKey` | `Terraform` | **In Progress** | Yes | Yes |  | Yes |  |  |  |  |
+| `iam` | `IAMWorkforcePool` | `DCL` | **Not Started** |  |  |  |  |  |  |  |  |
+| `iam` | `IAMWorkforcePoolProvider` | `DCL` | **Not Started** |  |  |  |  |  |  |  |  |
+| `iam` | `IAMWorkloadIdentityPool` | `DCL` | **Not Started** |  |  |  |  |  |  |  |  |
+| `iam` | `IAMWorkloadIdentityPoolProvider` | `DCL` | **Not Started** |  |  |  |  |  |  |  |  |
+| `iap` | `IAPBrand` | `DCL` | **In Progress** | Yes | Yes |  |  |  |  |  |  |
+| `iap` | `IAPIdentityAwareProxyClient` | `DCL` | **Not Started** |  |  |  |  |  |  |  |  |
+| `identityplatform` | `IdentityPlatformConfig` | `DCL` | **Not Started** |  |  |  |  |  |  |  |  |
+| `identityplatform` | `IdentityPlatformOAuthIDPConfig` | `DCL` | **Not Started** |  |  |  |  |  |  |  |  |
+| `identityplatform` | `IdentityPlatformTenant` | `DCL` | **Not Started** |  |  |  |  |  |  |  |  |
+| `identityplatform` | `IdentityPlatformTenantOAuthIDPConfig` | `DCL` | **Not Started** |  |  |  |  |  |  |  |  |
+| `kms` | `KMSCryptoKey` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `kms` | `KMSKeyRing` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `logging` | `LoggingLogBucket` | `DCL` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `logging` | `LoggingLogExclusion` | `DCL` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `logging` | `LoggingLogMetric` | `Direct` | **Completed** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| `logging` | `LoggingLogSink` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `logging` | `LoggingLogView` | `DCL` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `memcache` | `MemcacheInstance` | `Terraform` | **In Progress** |  |  |  | Yes |  |  |  |  |
+| `monitoring` | `MonitoringAlertPolicy` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `monitoring` | `MonitoringDashboard` | `Direct` | **Completed** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| `monitoring` | `MonitoringGroup` | `DCL` | **In Progress** | Yes | Yes |  | Yes |  |  |  |  |
+| `monitoring` | `MonitoringMetricDescriptor` | `DCL` | **In Progress** | Yes | Yes |  | Yes |  |  |  |  |
+| `monitoring` | `MonitoringMonitoredProject` | `DCL` | **In Progress** | Yes | Yes |  | Yes |  |  |  |  |
+| `monitoring` | `MonitoringNotificationChannel` | `Terraform` | **In Progress** | Yes | Yes |  | Yes |  |  |  |  |
+| `monitoring` | `MonitoringService` | `DCL` | **In Progress** | Yes | Yes |  | Yes |  |  |  |  |
+| `monitoring` | `MonitoringServiceLevelObjective` | `DCL` | **In Progress** |  |  |  | Yes |  |  |  |  |
+| `monitoring` | `MonitoringUptimeCheckConfig` | `DCL` | **In Progress** | Yes | Yes |  | Yes |  |  |  |  |
+| `networkconnectivity` | `NetworkConnectivityHub` | `DCL` | **In Progress** |  |  |  | Yes |  |  |  |  |
+| `networkconnectivity` | `NetworkConnectivitySpoke` | `DCL` | **In Progress** |  |  |  | Yes |  |  |  |  |
+| `networksecurity` | `NetworkSecurityAuthorizationPolicy` | `DCL` | **In Progress** | Yes | Yes |  | Yes |  |  |  |  |
+| `networksecurity` | `NetworkSecurityClientTLSPolicy` | `DCL` | **In Progress** | Yes | Yes |  |  |  |  |  |  |
+| `networksecurity` | `NetworkSecurityServerTLSPolicy` | `DCL` | **In Progress** |  |  |  | Yes |  |  |  |  |
+| `networkservices` | `NetworkServicesEndpointPolicy` | `DCL` | **Not Started** |  |  |  |  |  |  |  |  |
+| `networkservices` | `NetworkServicesGRPCRoute` | `DCL` | **Not Started** |  |  |  |  |  |  |  |  |
+| `networkservices` | `NetworkServicesGateway` | `DCL` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `networkservices` | `NetworkServicesHTTPRoute` | `DCL` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `networkservices` | `NetworkServicesMesh` | `DCL` | **In Progress** |  |  |  | Yes |  |  |  |  |
+| `networkservices` | `NetworkServicesTCPRoute` | `DCL` | **Not Started** |  |  |  |  |  |  |  |  |
+| `networkservices` | `NetworkServicesTLSRoute` | `DCL` | **Not Started** |  |  |  |  |  |  |  |  |
+| `osconfig` | `OSConfigGuestPolicy` | `DCL` | **In Progress** | Yes | Yes |  | Yes |  |  |  |  |
+| `osconfig` | `OSConfigOSPolicyAssignment` | `DCL` | **In Progress** | Yes | Yes |  |  |  |  |  |  |
+| `privateca` | `PrivateCACAPool` | `DCL` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `privateca` | `PrivateCACertificate` | `DCL` | **In Progress** | Yes | Yes |  |  |  |  |  |  |
+| `privateca` | `PrivateCACertificateAuthority` | `DCL` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `privateca` | `PrivateCACertificateTemplate` | `DCL` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `pubsub` | `PubSubSchema` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `pubsub` | `PubSubSubscription` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `pubsub` | `PubSubTopic` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `pubsublite` | `PubSubLiteReservation` | `Terraform` | **In Progress** |  |  |  | Yes |  |  |  |  |
+| `recaptchaenterprise` | `RecaptchaEnterpriseKey` | `DCL` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `redis` | `RedisInstance` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `resourcemanager` | `Folder` | `Terraform` | **In Progress** | Yes | Yes |  | Yes |  |  |  |  |
+| `resourcemanager` | `Project` | `Terraform` | **In Progress** | Yes | Yes |  | Yes |  |  |  |  |
+| `resourcemanager` | `ResourceManagerLien` | `Terraform` | **Not Started** |  |  |  |  |  |  |  |  |
+| `resourcemanager` | `ResourceManagerPolicy` | `Terraform` | **Not Started** |  |  |  |  |  |  |  |  |
+| `run` | `RunJob` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes |  | Yes |  |
+| `run` | `RunService` | `Terraform` | **In Progress** |  |  |  | Yes |  |  |  |  |
+| `secretmanager` | `SecretManagerSecret` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `secretmanager` | `SecretManagerSecretVersion` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes |  | Yes |  |
+| `servicedirectory` | `ServiceDirectoryEndpoint` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `servicedirectory` | `ServiceDirectoryNamespace` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `servicedirectory` | `ServiceDirectoryService` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `servicenetworking` | `ServiceNetworkingConnection` | `Terraform` | **In Progress** |  |  |  | Yes |  |  |  |  |
+| `serviceusage` | `Service` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `serviceusage` | `ServiceIdentity` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `sourcerepo` | `SourceRepoRepository` | `Terraform` | **Not Started** |  |  |  |  |  |  |  |  |
+| `spanner` | `SpannerDatabase` | `Terraform` | **In Progress** |  |  |  | Yes |  |  |  |  |
+| `spanner` | `SpannerInstance` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `sql` | `SQLDatabase` | `Terraform` | **In Progress** |  |  |  | Yes |  |  |  |  |
+| `sql` | `SQLInstance` | `Direct` | **Completed** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| `sql` | `SQLSSLCert` | `Terraform` | **Not Started** |  |  |  |  |  |  |  |  |
+| `sql` | `SQLUser` | `Terraform` | **In Progress** |  |  |  | Yes |  |  |  |  |
+| `storage` | `StorageBucket` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes |  |  |  |  |
+| `storage` | `StorageBucketAccessControl` | `Terraform` | **In Progress** |  |  |  | Yes |  |  |  |  |
+| `storage` | `StorageDefaultObjectAccessControl` | `Terraform` | **Not Started** |  |  |  |  |  |  |  |  |
+| `storage` | `StorageNotification` | `Terraform` | **In Progress** |  |  |  | Yes |  |  |  |  |
+| `storagetransfer` | `StorageTransferJob` | `Terraform` | **Not Started** |  |  |  |  |  |  |  |  |
+| `tags` | `TagsLocationTagBinding` | `Direct` | **Completed** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| `tags` | `TagsTagBinding` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `tags` | `TagsTagKey` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `tags` | `TagsTagValue` | `Terraform` | **In Progress** | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| `vertexai` | `VertexAIDataset` | `Terraform` | **In Progress** | Yes | Yes |  | Yes |  |  |  |  |
+| `vertexai` | `VertexAIEndpoint` | `Terraform` | **In Progress** |  |  |  | Yes |  |  |  |  |
+| `vertexai` | `VertexAIIndex` | `Terraform` | **Not Started** |  |  |  |  |  |  |  |  |
+| `vpcaccess` | `VPCAccessConnector` | `Terraform` | **In Progress** |  |  |  | Yes |  |  |  |  |
+
+</details>
+
+---
+
+## Architectural Analysis: Controller vs. Artifact Gaps
+
+<details>
+<summary>Click to expand architectural analysis of controller artifact gaps</summary>
+
+> [!NOTE]
+> A completed **Direct Controller** (`controller == Yes`) requires API types, identity/reference resolution, and resource mapping to function. For tracking purposes, controller completion implies prerequisite step completion.
+> Below is an architectural analysis of brownfield resources with controllers implemented (`controller == Yes`) that lack separate standalone identity/reference or mapper/fuzzer artifact files.
+
+### 1. Controllers / Types Missing Standalone Identity / Reference Files
+
+The following **7** resources lack separate standard `<kind_lower>_identity.go` or `<kind_lower>_reference.go` files in `apis/`:
+
+| Group | Kind | Reason / Actual File Placement |
+| :--- | :--- | :--- |
+| `accesscontextmanager` | `AccessContextManagerServicePerimeterResource` | Shared file placement: `accesscontextmanagerserviceperimeter_identity.go`, `accesscontextmanagerserviceperimeter_reference.go` |
+| `gkehub` | `GKEHubFeatureMembership` | Direct identity/ref logic embedded in controller adapter |
+| `iam` | `IAMPartialPolicy` | Custom IAM policy reference handling integrated into controller |
+| `iam` | `IAMPolicy` | Custom IAM policy reference handling integrated into controller |
+| `privateca` | `PrivateCACAPool` | Direct identity/ref logic embedded in controller adapter |
+| `sql` | `SQLInstance` | Direct identity/ref logic embedded in controller adapter |
+| `tags` | `TagsLocationTagBinding` | Direct identity/ref logic embedded in controller adapter |
+
+### 2. Controllers Missing Standalone Mapper or Fuzzer Files
+
+The following **51** resources have direct controllers implemented, but lack separate standalone mapper (`*_mapper.go`) AND fuzzer (`*_fuzzer.go`) files in `pkg/controller/direct/<group>/`:
+
+<details>
+<summary>Click to expand all 51 resources lacking strict standalone mapper/fuzzer files</summary>
+
+| Group | Kind |
+| :--- | :--- |
+| `alloydb` | `AlloyDBCluster` |
+| `alloydb` | `AlloyDBInstance` |
+| `artifactregistry` | `ArtifactRegistryRepository` |
+| `bigquery` | `BigQueryDataset` |
+| `bigquery` | `BigQueryTable` |
+| `billingbudgets` | `BillingBudgetsBudget` |
+| `certificatemanager` | `CertificateManagerCertificateMap` |
+| `certificatemanager` | `CertificateManagerCertificateMapEntry` |
+| `certificatemanager` | `CertificateManagerDNSAuthorization` |
+| `compute` | `ComputeAddress` |
+| `compute` | `ComputeExternalVPNGateway` |
+| `compute` | `ComputeNodeTemplate` |
+| `compute` | `ComputeSecurityPolicy` |
+| `dataflow` | `DataflowFlexTemplateJob` |
+| `dataflow` | `DataflowJob` |
+| `dataproc` | `DataprocAutoscalingPolicy` |
+| `dataproc` | `DataprocCluster` |
+| `dns` | `DNSManagedZone` |
+| `dns` | `DNSPolicy` |
+| `firestore` | `FirestoreIndex` |
+| `gkehub` | `GKEHubFeatureMembership` |
+| `iam` | `IAMPartialPolicy` |
+| `iam` | `IAMPolicy` |
+| `kms` | `KMSCryptoKey` |
+| `kms` | `KMSKeyRing` |
+| `logging` | `LoggingLogBucket` |
+| `logging` | `LoggingLogExclusion` |
+| `logging` | `LoggingLogMetric` |
+| `logging` | `LoggingLogSink` |
+| `logging` | `LoggingLogView` |
+| `monitoring` | `MonitoringAlertPolicy` |
+| `monitoring` | `MonitoringDashboard` |
+| `networkservices` | `NetworkServicesGateway` |
+| `privateca` | `PrivateCACAPool` |
+| `privateca` | `PrivateCACertificateAuthority` |
+| `privateca` | `PrivateCACertificateTemplate` |
+| `pubsub` | `PubSubSchema` |
+| `recaptchaenterprise` | `RecaptchaEnterpriseKey` |
+| `secretmanager` | `SecretManagerSecret` |
+| `secretmanager` | `SecretManagerSecretVersion` |
+| `servicedirectory` | `ServiceDirectoryEndpoint` |
+| `servicedirectory` | `ServiceDirectoryNamespace` |
+| `servicedirectory` | `ServiceDirectoryService` |
+| `serviceusage` | `Service` |
+| `serviceusage` | `ServiceIdentity` |
+| `spanner` | `SpannerInstance` |
+| `sql` | `SQLInstance` |
+| `tags` | `TagsLocationTagBinding` |
+| `tags` | `TagsTagBinding` |
+| `tags` | `TagsTagKey` |
+| `tags` | `TagsTagValue` |
+
+</details>
+
+### 3. Misplaced / Non-Standard Artifact Placements
+
+The following **34** resources have mapper/fuzzer symbols implemented, but placed in non-standard or shared filenames rather than standard `<kind_lower>_mapper.go` / `<kind_lower>_fuzzer.go` files:
+
+<details>
+<summary>Click to expand all 34 resources with misplaced artifact files</summary>
+
+| Group | Kind | Actual File Locations |
+| :--- | :--- | :--- |
+| `alloydb` | `AlloyDBCluster` | `alloydbcluster_controller.go`, `cluster_mappings.go`, `mapper.generated.go` |
+| `alloydb` | `AlloyDBInstance` | `alloydbinstance_controller.go`, `instance_mappings.go`, `mapper.generated.go` |
+| `bigquery` | `BigQueryTable` | `bigquerytable_controller.go` |
+| `billingbudgets` | `BillingBudgetsBudget` | `billingbudgetsbudget_controller.go`, `mapper.go` |
+| `dataflow` | `DataflowFlexTemplateJob` | `dataflowflextemplatejob_controller.go`, `mapper.generated.go` |
+| `dataflow` | `DataflowJob` | `mapper.generated.go`, `mapper.go` |
+| `gkehub` | `GKEHubFeatureMembership` | `gkehubfeaturemembership_controller.go`, `mappings.go` |
+| `iam` | `IAMPolicy` | `iampartialpolicy_controller.go`, `mappings.go` |
+| `kms` | `KMSKeyRing` | `kmskeyring_controller.go`, `kmskeyring_mappers.go` |
+| `logging` | `LoggingLogBucket` | `logginglogbucket_controller.go`, `mapper.generated.go`, `mapper.go` |
+| `logging` | `LoggingLogExclusion` | `logginglogexclusion_controller.go`, `mapper.generated.go`, `mapper.go` |
+| `logging` | `LoggingLogMetric` | `mapper.generated.go` |
+| `logging` | `LoggingLogSink` | `logginglogsink_controller.go`, `mapper.generated.go`, `mapper.go` |
+| `logging` | `LoggingLogView` | `logginglogview_controller.go`, `mapper.generated.go`, `mapper.go` |
+| `monitoring` | `MonitoringAlertPolicy` | `alertpolicy_mappings.go`, `mapper.generated.go`, `monitoringalertpolicy_controller.go` |
+| `monitoring` | `MonitoringDashboard` | `dashboard_generated.mappings.go`, `mapper.generated.go`, `monitoringdashboard_controller.go` |
+| `networkservices` | `NetworkServicesGateway` | `mappers.go`, `networkservicesgateway_controller.go` |
+| `privateca` | `PrivateCACAPool` | `mapper.generated.go`, `privatecacapool_controller.go` |
+| `privateca` | `PrivateCACertificateAuthority` | `mapper.generated.go`, `mapper.go`, `privatecacertificateauthority_controller.go` |
+| `privateca` | `PrivateCACertificateTemplate` | `mapper.generated.go`, `mapper.go`, `privatecacertificatetemplate_controller.go` |
+| `pubsub` | `PubSubSchema` | `mapper.generated.go`, `pubsubschema_controller.go` |
+| `recaptchaenterprise` | `RecaptchaEnterpriseKey` | `key_mappers.go`, `recaptchaenterprisekey_controller.go` |
+| `secretmanager` | `SecretManagerSecret` | `mapper.generated.go`, `secret_mapping.go`, `secretmanagersecret_controller.go` |
+| `secretmanager` | `SecretManagerSecretVersion` | `mapper.generated.go`, `secretmanagersecretversion_controller.go` |
+| `servicedirectory` | `ServiceDirectoryEndpoint` | `mapper.generated.go`, `mapper.go`, `servicedirectoryendpoint_controller.go` |
+| `servicedirectory` | `ServiceDirectoryNamespace` | `mapper.generated.go`, `mapper.go`, `servicedirectorynamespace_controller.go` |
+| `servicedirectory` | `ServiceDirectoryService` | `mapper.generated.go`, `mapper.go`, `servicedirectoryservice_controller.go` |
+| `serviceusage` | `Service` | `mapper.generated.go`, `mapper.go` |
+| `serviceusage` | `ServiceIdentity` | `mapper.generated.go` |
+| `spanner` | `SpannerInstance` | `spannerinstance_controller.go` |
+| `tags` | `TagsLocationTagBinding` | `mapper.generated.go`, `tagslocationtagbinding_controller.go` |
+| `tags` | `TagsTagBinding` | `mapper.generated.go`, `tagstagbinding_controller.go` |
+| `tags` | `TagsTagKey` | `mapper.generated.go`, `tagstagkey_controller.go` |
+| `tags` | `TagsTagValue` | `mapper.generated.go`, `tagstagvalue_controller.go` |
+
+</details>
+
+</details>

--- a/dev/migration-tracker/MIGRATION_STATUS.md
+++ b/dev/migration-tracker/MIGRATION_STATUS.md
@@ -28,34 +28,37 @@
 
 ---
 
-## Top Priority Unmigrated Resources (Dependency Order)
-| Topo Order | Group | Kind | State | Types | Ref/ID | Controller | Downstream Count |
-| :---: | :--- | :--- | :---: | :---: | :---: | :---: | :---: |
-| #1 | `resourcemanager` | `Folder` | **In Progress** | Yes | Yes |  | `452` |
-| #2 | `resourcemanager` | `Project` | **In Progress** | Yes | Yes |  | `447` |
-| #3 | `kms` | `KMSKeyRing` | **In Progress** | Yes | Yes | Yes | `142` |
-| #4 | `kms` | `KMSCryptoKey` | **In Progress** | Yes | Yes | Yes | `140` |
-| #5 | `compute` | `ComputeNetwork` | **In Progress** | Yes | Yes | Yes | `136` |
-| #6 | `iam` | `IAMServiceAccount` | **In Progress** | Yes | Yes |  | `61` |
-| #7 | `storage` | `StorageBucket` | **In Progress** | Yes | Yes |  | `42` |
-| #8 | `compute` | `ComputeSubnetwork` | **In Progress** | Yes | Yes |  | `23` |
-| #9 | `serviceusage` | `Service` | **In Progress** | Yes | Yes | Yes | `15` |
-| #10 | `compute` | `ComputeSecurityPolicy` | **In Progress** | Yes | Yes | Yes | `13` |
-| #11 | `compute` | `ComputeHealthCheck` | **In Progress** | Yes |  |  | `12` |
-| #12 | `compute` | `ComputeHTTPHealthCheck` | **In Progress** | Yes | Yes | Yes | `11` |
-| #13 | `compute` | `ComputeNetworkEndpointGroup` | **In Progress** | Yes | Yes |  | `11` |
-| #14 | `compute` | `ComputeInstanceGroup` | **In Progress** | Yes | Yes | Yes | `10` |
-| #15 | `compute` | `ComputeBackendService` | **In Progress** | Yes | Yes |  | `9` |
-| #16 | `bigtable` | `BigtableInstance` | **In Progress** | Yes | Yes |  | `8` |
-| #17 | `pubsub` | `PubSubSchema` | **In Progress** | Yes | Yes | Yes | `8` |
-| #18 | `apigee` | `ApigeeOrganization` | **In Progress** | Yes | Yes |  | `7` |
-| #19 | `compute` | `ComputeBackendBucket` | **In Progress** | Yes |  |  | `7` |
-| #20 | `compute` | `ComputeInstanceTemplate` | **In Progress** |  |  |  | `7` |
-| #21 | `pubsub` | `PubSubTopic` | **In Progress** | Yes | Yes | Yes | `7` |
-| #22 | `compute` | `ComputeRouter` | **In Progress** | Yes | Yes | Yes | `6` |
-| #23 | `dataproc` | `DataprocCluster` | **In Progress** | Yes | Yes | Yes | `6` |
-| #24 | `compute` | `ComputeTargetVPNGateway` | **In Progress** | Yes |  |  | `5` |
-| #25 | `compute` | `ComputeURLMap` | **In Progress** | Yes | Yes | Yes | `5` |
+## Unmigrated Resources with Most Dependencies
+
+This section lists unmigrated brownfield resources ordered by their downstream dependency count (topological order). Resources with higher downstream counts are referenced by many other KCC resources, making them critical candidates to unblock migration pipelines.
+
+| Topo Order | Group | Kind | Downstream Dependents | State | Next Step |
+| :---: | :--- | :--- | :---: | :---: | :--- |
+| #1 | `resourcemanager` | `Folder` | `452` | **In Progress** | `Mapper/Fuzz` |
+| #2 | `resourcemanager` | `Project` | `447` | **In Progress** | `Mapper/Fuzz` |
+| #3 | `kms` | `KMSKeyRing` | `142` | **In Progress** | `Default to Direct Controller` |
+| #4 | `kms` | `KMSCryptoKey` | `140` | **In Progress** | `Default to Direct Controller` |
+| #5 | `compute` | `ComputeNetwork` | `136` | **In Progress** | `Default to Direct Controller` |
+| #6 | `iam` | `IAMServiceAccount` | `61` | **In Progress** | `Mapper/Fuzz` |
+| #7 | `storage` | `StorageBucket` | `42` | **In Progress** | `Controller` |
+| #8 | `compute` | `ComputeSubnetwork` | `23` | **In Progress** | `Mapper/Fuzz` |
+| #9 | `serviceusage` | `Service` | `15` | **In Progress** | `Default to Direct Controller` |
+| #10 | `compute` | `ComputeSecurityPolicy` | `13` | **In Progress** | `Default to Direct Controller` |
+| #11 | `compute` | `ComputeHealthCheck` | `12` | **In Progress** | `Identity/Ref` |
+| #12 | `compute` | `ComputeHTTPHealthCheck` | `11` | **In Progress** | `Default to Direct Controller` |
+| #13 | `compute` | `ComputeNetworkEndpointGroup` | `11` | **In Progress** | `Mocks` |
+| #14 | `compute` | `ComputeInstanceGroup` | `10` | **In Progress** | `Default to Direct Controller` |
+| #15 | `compute` | `ComputeBackendService` | `9` | **In Progress** | `Mapper/Fuzz` |
+| #16 | `bigtable` | `BigtableInstance` | `8` | **In Progress** | `Mapper/Fuzz` |
+| #17 | `pubsub` | `PubSubSchema` | `8` | **In Progress** | `Default to Direct Controller` |
+| #18 | `apigee` | `ApigeeOrganization` | `7` | **In Progress** | `Mapper/Fuzz` |
+| #19 | `compute` | `ComputeBackendBucket` | `7` | **In Progress** | `Identity/Ref` |
+| #20 | `compute` | `ComputeInstanceTemplate` | `7` | **In Progress** | `Types` |
+| #21 | `pubsub` | `PubSubTopic` | `7` | **In Progress** | `Default to Direct Controller` |
+| #22 | `compute` | `ComputeRouter` | `6` | **In Progress** | `Default to Direct Controller` |
+| #23 | `dataproc` | `DataprocCluster` | `6` | **In Progress** | `Default to Direct Controller` |
+| #24 | `compute` | `ComputeTargetVPNGateway` | `5` | **In Progress** | `Identity/Ref` |
+| #25 | `compute` | `ComputeURLMap` | `5` | **In Progress** | `Default to Direct Controller` |
 
 ---
 ## Resource Migration Progress by Service / Group
@@ -65,66 +68,66 @@
 
 | Group | Total | Completed | In Progress | Not Started | % Complete |
 | :--- | :---: | :---: | :---: | :---: | :---: |
-| `compute` | 56 | 1 | 52 | 3 | `1.8%` |
-| `iam` | 12 | 0 | 6 | 6 | `0.0%` |
-| `monitoring` | 9 | 1 | 8 | 0 | `11.1%` |
-| `networkservices` | 7 | 0 | 3 | 4 | `0.0%` |
-| `logging` | 5 | 1 | 4 | 0 | `20.0%` |
 | `accesscontextmanager` | 4 | 0 | 4 | 0 | `0.0%` |
 | `alloydb` | 4 | 1 | 3 | 0 | `25.0%` |
+| `apigee` | 2 | 0 | 2 | 0 | `0.0%` |
+| `artifactregistry` | 1 | 0 | 1 | 0 | `0.0%` |
 | `bigquery` | 4 | 0 | 3 | 1 | `0.0%` |
 | `bigtable` | 4 | 0 | 4 | 0 | `0.0%` |
-| `certificatemanager` | 4 | 1 | 3 | 0 | `25.0%` |
-| `dlp` | 4 | 0 | 0 | 4 | `0.0%` |
-| `identityplatform` | 4 | 0 | 0 | 4 | `0.0%` |
-| `privateca` | 4 | 0 | 4 | 0 | `0.0%` |
-| `resourcemanager` | 4 | 0 | 2 | 2 | `0.0%` |
-| `sql` | 4 | 1 | 2 | 1 | `25.0%` |
-| `storage` | 4 | 0 | 3 | 1 | `0.0%` |
-| `tags` | 4 | 1 | 3 | 0 | `25.0%` |
-| `dataproc` | 3 | 0 | 3 | 0 | `0.0%` |
-| `dns` | 3 | 0 | 3 | 0 | `0.0%` |
-| `edgecontainer` | 3 | 0 | 2 | 1 | `0.0%` |
-| `gkehub` | 3 | 1 | 2 | 0 | `33.3%` |
-| `networksecurity` | 3 | 0 | 3 | 0 | `0.0%` |
-| `pubsub` | 3 | 0 | 3 | 0 | `0.0%` |
-| `servicedirectory` | 3 | 0 | 3 | 0 | `0.0%` |
-| `vertexai` | 3 | 0 | 2 | 1 | `0.0%` |
-| `apigee` | 2 | 0 | 2 | 0 | `0.0%` |
-| `binaryauthorization` | 2 | 0 | 0 | 2 | `0.0%` |
-| `cloudidentity` | 2 | 2 | 0 | 0 | `100.0%` |
-| `container` | 2 | 0 | 2 | 0 | `0.0%` |
-| `datacatalog` | 2 | 0 | 2 | 0 | `0.0%` |
-| `dataflow` | 2 | 0 | 2 | 0 | `0.0%` |
-| `edgenetwork` | 2 | 0 | 2 | 0 | `0.0%` |
-| `filestore` | 2 | 0 | 1 | 1 | `0.0%` |
-| `iap` | 2 | 0 | 1 | 1 | `0.0%` |
-| `kms` | 2 | 0 | 2 | 0 | `0.0%` |
-| `networkconnectivity` | 2 | 0 | 2 | 0 | `0.0%` |
-| `osconfig` | 2 | 0 | 2 | 0 | `0.0%` |
-| `run` | 2 | 0 | 2 | 0 | `0.0%` |
-| `secretmanager` | 2 | 0 | 2 | 0 | `0.0%` |
-| `serviceusage` | 2 | 0 | 2 | 0 | `0.0%` |
-| `spanner` | 2 | 0 | 2 | 0 | `0.0%` |
-| `artifactregistry` | 1 | 0 | 1 | 0 | `0.0%` |
 | `billingbudgets` | 1 | 0 | 1 | 0 | `0.0%` |
+| `binaryauthorization` | 2 | 0 | 0 | 2 | `0.0%` |
+| `certificatemanager` | 4 | 1 | 3 | 0 | `25.0%` |
 | `cloudbuild` | 1 | 0 | 1 | 0 | `0.0%` |
 | `cloudfunctions` | 1 | 0 | 1 | 0 | `0.0%` |
+| `cloudidentity` | 2 | 2 | 0 | 0 | `100.0%` |
 | `cloudids` | 1 | 0 | 1 | 0 | `0.0%` |
 | `cloudscheduler` | 1 | 0 | 0 | 1 | `0.0%` |
+| `compute` | 56 | 1 | 52 | 3 | `1.8%` |
 | `configcontroller` | 1 | 0 | 0 | 1 | `0.0%` |
+| `container` | 2 | 0 | 2 | 0 | `0.0%` |
 | `containeranalysis` | 1 | 0 | 1 | 0 | `0.0%` |
 | `containerattached` | 1 | 0 | 1 | 0 | `0.0%` |
+| `datacatalog` | 2 | 0 | 2 | 0 | `0.0%` |
+| `dataflow` | 2 | 0 | 2 | 0 | `0.0%` |
 | `datafusion` | 1 | 0 | 0 | 1 | `0.0%` |
+| `dataproc` | 3 | 0 | 3 | 0 | `0.0%` |
+| `dlp` | 4 | 0 | 0 | 4 | `0.0%` |
+| `dns` | 3 | 0 | 3 | 0 | `0.0%` |
+| `edgecontainer` | 3 | 0 | 2 | 1 | `0.0%` |
+| `edgenetwork` | 2 | 0 | 2 | 0 | `0.0%` |
 | `eventarc` | 1 | 0 | 0 | 1 | `0.0%` |
+| `filestore` | 2 | 0 | 1 | 1 | `0.0%` |
 | `firestore` | 1 | 0 | 1 | 0 | `0.0%` |
+| `gkehub` | 3 | 1 | 2 | 0 | `33.3%` |
+| `iam` | 12 | 0 | 6 | 6 | `0.0%` |
+| `iap` | 2 | 0 | 1 | 1 | `0.0%` |
+| `identityplatform` | 4 | 0 | 0 | 4 | `0.0%` |
+| `kms` | 2 | 0 | 2 | 0 | `0.0%` |
+| `logging` | 5 | 1 | 4 | 0 | `20.0%` |
 | `memcache` | 1 | 0 | 1 | 0 | `0.0%` |
+| `monitoring` | 9 | 1 | 8 | 0 | `11.1%` |
+| `networkconnectivity` | 2 | 0 | 2 | 0 | `0.0%` |
+| `networksecurity` | 3 | 0 | 3 | 0 | `0.0%` |
+| `networkservices` | 7 | 0 | 3 | 4 | `0.0%` |
+| `osconfig` | 2 | 0 | 2 | 0 | `0.0%` |
+| `privateca` | 4 | 0 | 4 | 0 | `0.0%` |
+| `pubsub` | 3 | 0 | 3 | 0 | `0.0%` |
 | `pubsublite` | 1 | 0 | 1 | 0 | `0.0%` |
 | `recaptchaenterprise` | 1 | 0 | 1 | 0 | `0.0%` |
 | `redis` | 1 | 0 | 1 | 0 | `0.0%` |
+| `resourcemanager` | 4 | 0 | 2 | 2 | `0.0%` |
+| `run` | 2 | 0 | 2 | 0 | `0.0%` |
+| `secretmanager` | 2 | 0 | 2 | 0 | `0.0%` |
+| `servicedirectory` | 3 | 0 | 3 | 0 | `0.0%` |
 | `servicenetworking` | 1 | 0 | 1 | 0 | `0.0%` |
+| `serviceusage` | 2 | 0 | 2 | 0 | `0.0%` |
 | `sourcerepo` | 1 | 0 | 0 | 1 | `0.0%` |
+| `spanner` | 2 | 0 | 2 | 0 | `0.0%` |
+| `sql` | 4 | 1 | 2 | 1 | `25.0%` |
+| `storage` | 4 | 0 | 3 | 1 | `0.0%` |
 | `storagetransfer` | 1 | 0 | 0 | 1 | `0.0%` |
+| `tags` | 4 | 1 | 3 | 0 | `25.0%` |
+| `vertexai` | 3 | 0 | 2 | 1 | `0.0%` |
 | `vpcaccess` | 1 | 0 | 1 | 0 | `0.0%` |
 
 </details>

--- a/dev/migration-tracker/README.md
+++ b/dev/migration-tracker/README.md
@@ -1,25 +1,54 @@
 # KCC Direct Migration Tracker
 
-This folder contains a static website and metadata file for tracking the migration of KCC resources from Terraform/DCL to Direct Controllers.
+This folder tracks the migration of Config Connector (KCC) resources from legacy controllers (`Terraform` or `DCL`) to `Direct` controllers.
+
+The primary status document is **[`MIGRATION_STATUS.md`](./MIGRATION_STATUS.md)**.
+
+## How to View Migration Status
+
+- **Primary (Markdown Dashboard)**: View **[`MIGRATION_STATUS.md`](./MIGRATION_STATUS.md)** directly for live progress metrics, dependency priority rankings, step implementation status, and full resource registries.
+- **Optional Web UI**: You can serve the static web dashboard locally if desired:
+  ```bash
+  cd dev/migration-tracker
+  python3 -m http.server 8000
+  ```
+  Then open [http://localhost:8000](http://localhost:8000) in your web browser.
+
+## Scope of Brownfield Migration
+
+The migration tracker specifically targets **v1beta1 Brownfield resources**:
+- **Included**: Legacy resources registered in [`pkg/controller/resourceconfig/static_config.go`](../../pkg/controller/resourceconfig/static_config.go) whose `SupportedControllers` includes legacy reconcilers (`Terraform` or `DCL`) and have reached `v1beta1` API maturity.
+- **Excluded**:
+  - **Pure Greenfield Resources**: Resources built from scratch using the direct controller architecture (where `SupportedControllers` contains only `Direct`).
+  - **`v1alpha1`-Only Resources**: Experimental or alpha resources that have not yet been promoted to `v1beta1`.
+
+## Data Generation & Architecture
+
+The migration tracking workflow uses a clean two-stage pipeline:
+
+1. **[`generate_data.py`](./generate_data.py)**: Performs disk scanning across the repository:
+   - Scans `apis/<group>/<version>/` for Go API types, strictly checking for standard `<kind_lower>_identity.go` and `<kind_lower>_reference.go` files (while detecting shared/non-standard file placements).
+   - Scans `pkg/controller/direct/<group>/` for direct controller adapters (`*_controller.go`), mappers (`*_mapper.go`), and fuzzers (`*_fuzzer.go`).
+   - Analyzes CRD schema dependencies in `config/crds/resources/` to calculate topological ordering.
+   - Outputs the complete dataset to [`data.json`](./data.json).
+
+2. **[`generate_md.py`](./generate_md.py)**: Pure Markdown generator:
+   - Invokes `generate_data.py` to ensure dataset freshness.
+   - Reads `data.json` and renders [`MIGRATION_STATUS.md`](./MIGRATION_STATUS.md), including progress metrics, step completion breakdown, topologically sorted priority list, complete resource registry, and architectural gap analysis.
 
 ## Files
 
-- `data.json`: The metadata file containing all the KCC resources and their migration status, dependencies, and steps.
-- `index.html`: The static webpage to display the data.
-- `app.js` & `style.css`: The UI logic and styles.
-- `generate_data.py`: A Python script to scaffold `data.json` initially from `hack/resource-dependencies.md`.
+- [`MIGRATION_STATUS.md`](./MIGRATION_STATUS.md): Primary auto-generated Markdown dashboard visualizing progress metrics, dependency priority rankings, resource registries, and architectural gap analysis.
+- [`generate_md.py`](./generate_md.py): Python script to regenerate `MIGRATION_STATUS.md` from `data.json`.
+- [`generate_data.py`](./generate_data.py): Python script to scan the codebase and update `data.json`.
+- [`data.json`](./data.json): Structured dataset containing in-scope v1beta1 brownfield KCC resources, migration steps, artifact metadata, and dependencies.
+- [`list_top_unmigrated.py`](./list_top_unmigrated.py): CLI script to list unmigrated resources sorted by topological dependency priority.
+- `index.html`, `app.js`, `style.css`: Optional static web UI dashboard.
 
-## How to View Locally
+## Updating Data & Dashboard
 
-You can run any simple HTTP server to serve the static files. For example, using Python 3:
+To update resource status data and regenerate the markdown dashboard, run:
 
 ```bash
-cd dev/migration-tracker
-python3 -m http.server 8000
+python3 dev/migration-tracker/generate_md.py
 ```
-
-Then open [http://localhost:8000](http://localhost:8000) in your web browser.
-
-## Updating Data
-
-To update the status of a migration, simply edit `data.json` and change the relevant fields. For example, changing `"state": "Not Started"` to `"state": "In Progress"` or updating `"steps"`.

--- a/dev/migration-tracker/README.md
+++ b/dev/migration-tracker/README.md
@@ -7,12 +7,7 @@ The primary status document is **[`MIGRATION_STATUS.md`](./MIGRATION_STATUS.md)*
 ## How to View Migration Status
 
 - **Primary (Markdown Dashboard)**: View **[`MIGRATION_STATUS.md`](./MIGRATION_STATUS.md)** directly for live progress metrics, dependency priority rankings, step implementation status, and full resource registries.
-- **Optional Web UI**: You can serve the static web dashboard locally if desired:
-  ```bash
-  cd dev/migration-tracker
-  python3 -m http.server 8000
-  ```
-  Then open [http://localhost:8000](http://localhost:8000) in your web browser.
+- **Web Dashboard**: View the hosted interactive dashboard at **[https://googlecloudplatform.github.io/k8s-config-connector/migration-tracker/#](https://googlecloudplatform.github.io/k8s-config-connector/migration-tracker/#)** (may be outdated). Alternatively, you can serve it locally using `python3 -m http.server 8000` in this directory.
 
 ## Scope of Brownfield Migration
 

--- a/dev/migration-tracker/data.json
+++ b/dev/migration-tracker/data.json
@@ -1,84 +1,5 @@
 [
   {
-    "group": "apigateway",
-    "kind": "APIGatewayAPIConfig",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 78,
-    "downstreamCount": 0
-  },
-  {
-    "group": "apigateway",
-    "kind": "APIGatewayGateway",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 79,
-    "downstreamCount": 0
-  },
-  {
-    "group": "apikeys",
-    "kind": "APIKeysKey",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Direct",
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 80,
-    "downstreamCount": 0
-  },
-  {
     "group": "accesscontextmanager",
     "kind": "AccessContextManagerAccessLevel",
     "version": "v1beta1",
@@ -102,34 +23,18 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 35,
-    "downstreamCount": 2
-  },
-  {
-    "group": "accesscontextmanager",
-    "kind": "AccessContextManagerAccessLevelCondition",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "AccessContextManagerAccessLevel"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 81,
-    "downstreamCount": 0
+    "sortOrder": 36,
+    "downstreamCount": 2,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go"
+      ]
+    }
   },
   {
     "group": "accesscontextmanager",
@@ -152,32 +57,18 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 32,
-    "downstreamCount": 3
-  },
-  {
-    "group": "accesscontextmanager",
-    "kind": "AccessContextManagerGCPUserAccessBinding",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 82,
-    "downstreamCount": 0
+    "sortOrder": 33,
+    "downstreamCount": 3,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go"
+      ]
+    }
   },
   {
     "group": "accesscontextmanager",
@@ -205,8 +96,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 83,
-    "downstreamCount": 0
+    "sortOrder": 79,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "accesscontextmanager",
@@ -221,16 +120,27 @@
     "state": "In Progress",
     "steps": {
       "gen-types": true,
-      "identity-reference": true,
+      "identity-reference": false,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 84,
-    "downstreamCount": 0
+    "notes": "Missing _reference.go or _identity.go",
+    "sortOrder": 80,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [
+        "accesscontextmanagerserviceperimeter_identity.go",
+        "accesscontextmanagerserviceperimeter_reference.go"
+      ],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "alloydb",
@@ -255,8 +165,18 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 85,
-    "downstreamCount": 0
+    "sortOrder": 81,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go"
+      ]
+    }
   },
   {
     "group": "alloydb",
@@ -273,6 +193,44 @@
       "KMSCryptoKey",
       "Project"
     ],
+    "state": "In Progress",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "",
+    "sortOrder": 37,
+    "downstreamCount": 2,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "alloydbcluster_controller.go",
+        "cluster_mappings.go",
+        "mapper.generated.go"
+      ]
+    }
+  },
+  {
+    "group": "alloydb",
+    "kind": "AlloyDBInstance",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [
+      "AlloyDBCluster"
+    ],
     "state": "Completed",
     "steps": {
       "gen-types": true,
@@ -284,8 +242,20 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 36,
-    "downstreamCount": 2
+    "sortOrder": 82,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "alloydbinstance_controller.go",
+        "instance_mappings.go",
+        "mapper.generated.go"
+      ]
+    }
   },
   {
     "group": "alloydb",
@@ -304,38 +274,25 @@
       "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 86,
-    "downstreamCount": 0
-  },
-  {
-    "group": "apigee",
-    "kind": "ApigeeAddonsConfig",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 87,
-    "downstreamCount": 0
+    "sortOrder": 83,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go",
+        "user_mappings.go"
+      ]
+    }
   },
   {
     "group": "apigee",
@@ -354,38 +311,22 @@
       "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 37,
-    "downstreamCount": 2
-  },
-  {
-    "group": "apigee",
-    "kind": "ApigeeNATAddress",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 88,
-    "downstreamCount": 0
+    "sortOrder": 38,
+    "downstreamCount": 2,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "apigee",
@@ -405,162 +346,22 @@
       "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 18,
-    "downstreamCount": 7
-  },
-  {
-    "group": "apigee",
-    "kind": "ApigeeSyncAuthorization",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 89,
-    "downstreamCount": 0
-  },
-  {
-    "group": "appengine",
-    "kind": "AppEngineDomainMapping",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 90,
-    "downstreamCount": 0
-  },
-  {
-    "group": "appengine",
-    "kind": "AppEngineFirewallRule",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 91,
-    "downstreamCount": 0
-  },
-  {
-    "group": "appengine",
-    "kind": "AppEngineFlexibleAppVersion",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Service"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 92,
-    "downstreamCount": 0
-  },
-  {
-    "group": "appengine",
-    "kind": "AppEngineServiceSplitTraffic",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 93,
-    "downstreamCount": 0
-  },
-  {
-    "group": "appengine",
-    "kind": "AppEngineStandardAppVersion",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Service"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 94,
-    "downstreamCount": 0
+    "downstreamCount": 7,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "artifactregistry",
@@ -575,7 +376,7 @@
     "dependencies": [
       "KMSCryptoKey"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -586,112 +387,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 95,
-    "downstreamCount": 0
-  },
-  {
-    "group": "beyondcorp",
-    "kind": "BeyondCorpAppConnection",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 96,
-    "downstreamCount": 0
-  },
-  {
-    "group": "beyondcorp",
-    "kind": "BeyondCorpAppConnector",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 97,
-    "downstreamCount": 0
-  },
-  {
-    "group": "beyondcorp",
-    "kind": "BeyondCorpAppGateway",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 98,
-    "downstreamCount": 0
-  },
-  {
-    "group": "bigquerydatapolicy",
-    "kind": "BigQueryDataPolicyDataPolicy",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 99,
-    "downstreamCount": 0
+    "sortOrder": 84,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "bigquery",
@@ -707,7 +412,7 @@
       "KMSCryptoKey",
       "Project"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -718,34 +423,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 26,
-    "downstreamCount": 4
-  },
-  {
-    "group": "bigquery",
-    "kind": "BigQueryDatasetAccess",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "In Progress",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go or _identity.go",
-    "sortOrder": 100,
-    "downstreamCount": 0
+    "sortOrder": 27,
+    "downstreamCount": 4,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "bigquery",
@@ -772,35 +459,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 101,
-    "downstreamCount": 0
-  },
-  {
-    "group": "bigqueryreservation",
-    "kind": "BigQueryReservationCapacityCommitment",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Direct",
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 102,
-    "downstreamCount": 0
+    "sortOrder": 85,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "bigquery",
@@ -815,19 +483,27 @@
       "BigQueryDataset",
       "Project"
     ],
-    "state": "Not Started",
+    "state": "In Progress",
     "steps": {
       "gen-types": false,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 103,
-    "downstreamCount": 0
+    "sortOrder": 86,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "bigquery",
@@ -843,7 +519,7 @@
       "BigQueryDataset",
       "KMSCryptoKey"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -854,8 +530,18 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 56,
-    "downstreamCount": 1
+    "sortOrder": 57,
+    "downstreamCount": 1,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "bigquerytable_controller.go"
+      ]
+    }
   },
   {
     "group": "bigtable",
@@ -870,7 +556,7 @@
     "dependencies": [
       "BigtableInstance"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -881,8 +567,18 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 104,
-    "downstreamCount": 0
+    "sortOrder": 87,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "bigtableappprofile_controller.go"
+      ]
+    }
   },
   {
     "group": "bigtable",
@@ -898,7 +594,7 @@
       "BigtableInstance",
       "BigtableTable"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -909,8 +605,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 105,
-    "downstreamCount": 0
+    "sortOrder": 88,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "bigtable",
@@ -929,14 +633,22 @@
       "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 16,
-    "downstreamCount": 8
+    "downstreamCount": 8,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "bigtable",
@@ -954,15 +666,23 @@
     "steps": {
       "gen-types": true,
       "identity-reference": true,
-      "mapper-fuzzer": false,
-      "mocks": false,
+      "mapper-fuzzer": true,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 38,
-    "downstreamCount": 2
+    "sortOrder": 39,
+    "downstreamCount": 2,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "billingbudgets",
@@ -971,7 +691,8 @@
     "controllerType": "DCL",
     "defaultController": "DCL",
     "supportedControllers": [
-      "DCL"
+      "DCL",
+      "Direct"
     ],
     "dependencies": [
       "PubSubTopic"
@@ -980,15 +701,26 @@
     "steps": {
       "gen-types": true,
       "identity-reference": true,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 106,
-    "downstreamCount": 0
+    "sortOrder": 89,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "billingbudgetsbudget_controller.go",
+        "mapper.go"
+      ]
+    }
   },
   {
     "group": "binaryauthorization",
@@ -1013,8 +745,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 107,
-    "downstreamCount": 0
+    "sortOrder": 90,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "binaryauthorization",
@@ -1039,8 +779,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 108,
-    "downstreamCount": 0
+    "sortOrder": 91,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "certificatemanager",
@@ -1055,7 +803,7 @@
     "dependencies": [
       "Project"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -1066,8 +814,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 109,
-    "downstreamCount": 0
+    "sortOrder": 92,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "certificatemanager",
@@ -1082,7 +838,7 @@
     "dependencies": [
       "Project"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -1093,8 +849,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 110,
-    "downstreamCount": 0
+    "sortOrder": 93,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "certificatemanager",
@@ -1109,6 +873,40 @@
     "dependencies": [
       "Project"
     ],
+    "state": "In Progress",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "",
+    "sortOrder": 94,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
+  },
+  {
+    "group": "certificatemanager",
+    "kind": "CertificateManagerDNSAuthorization",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [
+      "Project"
+    ],
     "state": "Completed",
     "steps": {
       "gen-types": true,
@@ -1120,84 +918,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 111,
-    "downstreamCount": 0
-  },
-  {
-    "group": "cloudasset",
-    "kind": "CloudAssetFolderFeed",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Folder"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 112,
-    "downstreamCount": 0
-  },
-  {
-    "group": "cloudasset",
-    "kind": "CloudAssetOrganizationFeed",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 113,
-    "downstreamCount": 0
-  },
-  {
-    "group": "cloudasset",
-    "kind": "CloudAssetProjectFeed",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 114,
-    "downstreamCount": 0
+    "sortOrder": 95,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "cloudbuild",
@@ -1216,33 +946,7 @@
     "state": "In Progress",
     "steps": {
       "gen-types": true,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go or _identity.go",
-    "sortOrder": 115,
-    "downstreamCount": 0
-  },
-  {
-    "group": "cloudfunctions2",
-    "kind": "CloudFunctions2Function",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -1250,8 +954,19 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 116,
-    "downstreamCount": 0
+    "sortOrder": 96,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "trigger_mappings.go",
+        "trigger_test.go"
+      ]
+    }
   },
   {
     "group": "cloudfunctions",
@@ -1266,19 +981,27 @@
       "IAMServiceAccount",
       "Project"
     ],
-    "state": "Not Started",
+    "state": "In Progress",
     "steps": {
       "gen-types": false,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 117,
-    "downstreamCount": 0
+    "sortOrder": 97,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "cloudids",
@@ -1293,67 +1016,93 @@
       "ComputeNetwork",
       "Project"
     ],
-    "state": "Not Started",
+    "state": "In Progress",
     "steps": {
       "gen-types": false,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 118,
-    "downstreamCount": 0
+    "sortOrder": 98,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
-    "group": "cloudiot",
-    "kind": "CloudIOTDevice",
+    "group": "cloudidentity",
+    "kind": "CloudIdentityGroup",
     "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
     "supportedControllers": [
-      "Terraform"
+      "Direct"
     ],
     "dependencies": [],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 119,
-    "downstreamCount": 0
+    "sortOrder": 58,
+    "downstreamCount": 1,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
-    "group": "cloudiot",
-    "kind": "CloudIOTDeviceRegistry",
+    "group": "cloudidentity",
+    "kind": "CloudIdentityMembership",
     "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
     "supportedControllers": [
-      "Terraform"
+      "Direct"
     ],
-    "dependencies": [],
-    "state": "Not Started",
+    "dependencies": [
+      "CloudIdentityGroup"
+    ],
+    "state": "Completed",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 120,
-    "downstreamCount": 0
+    "sortOrder": 99,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "cloudscheduler",
@@ -1378,8 +1127,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 121,
-    "downstreamCount": 0
+    "sortOrder": 100,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -1395,7 +1152,7 @@
       "ComputeNetwork",
       "ComputeSubnetwork"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -1406,35 +1163,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 39,
-    "downstreamCount": 2
-  },
-  {
-    "group": "compute",
-    "kind": "ComputeAutoscaler",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Direct",
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 122,
-    "downstreamCount": 0
+    "sortOrder": 40,
+    "downstreamCount": 2,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -1452,42 +1190,23 @@
     "steps": {
       "gen-types": true,
       "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
+      "mapper-fuzzer": true,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go or _identity.go",
     "sortOrder": 19,
-    "downstreamCount": 7
-  },
-  {
-    "group": "compute",
-    "kind": "ComputeBackendBucketSignedURLKey",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "ComputeBackendBucket",
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 123,
-    "downstreamCount": 0
+    "downstreamCount": 7,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -1506,47 +1225,27 @@
       "ComputeNetworkEndpointGroup",
       "ComputeSecurityPolicy"
     ],
-    "state": "Not Started",
+    "state": "In Progress",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
+      "gen-types": true,
+      "identity-reference": true,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 15,
-    "downstreamCount": 9
-  },
-  {
-    "group": "compute",
-    "kind": "ComputeBackendServiceSignedURLKey",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Direct",
-      "Terraform"
-    ],
-    "dependencies": [
-      "ComputeBackendService",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 124,
-    "downstreamCount": 0
+    "downstreamCount": 9,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -1564,7 +1263,7 @@
       "KMSCryptoKey",
       "Project"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -1575,36 +1274,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 297,
-    "downstreamCount": 4
-  },
-  {
-    "group": "compute",
-    "kind": "ComputeDiskResourcePolicyAttachment",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Direct",
-      "Terraform"
-    ],
-    "dependencies": [
-      "ComputeDisk",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 298,
-    "downstreamCount": 0
+    "sortOrder": 210,
+    "downstreamCount": 4,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -1617,7 +1296,7 @@
       "Terraform"
     ],
     "dependencies": [],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -1628,8 +1307,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 125,
-    "downstreamCount": 0
+    "sortOrder": 101,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -1644,7 +1331,7 @@
     "dependencies": [
       "ComputeNetwork"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -1655,8 +1342,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 126,
-    "downstreamCount": 0
+    "sortOrder": 102,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -1671,7 +1366,7 @@
     "dependencies": [
       "Folder"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -1682,8 +1377,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 27,
-    "downstreamCount": 4
+    "sortOrder": 28,
+    "downstreamCount": 4,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -1701,15 +1404,57 @@
     "steps": {
       "gen-types": true,
       "identity-reference": false,
-      "mapper-fuzzer": false,
+      "mapper-fuzzer": true,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go or _identity.go",
-    "sortOrder": 127,
-    "downstreamCount": 0
+    "sortOrder": 103,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeFirewallPolicyRule",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [
+      "ComputeFirewallPolicy"
+    ],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "",
+    "sortOrder": 104,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -1734,7 +1479,7 @@
       "ComputeTargetTCPProxy",
       "ComputeTargetVPNGateway"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -1745,60 +1490,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 57,
-    "downstreamCount": 1
-  },
-  {
-    "group": "compute",
-    "kind": "ComputeGlobalNetworkEndpoint",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 128,
-    "downstreamCount": 0
-  },
-  {
-    "group": "compute",
-    "kind": "ComputeGlobalNetworkEndpointGroup",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 129,
-    "downstreamCount": 0
+    "sortOrder": 59,
+    "downstreamCount": 1,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -1811,7 +1512,7 @@
       "Terraform"
     ],
     "dependencies": [],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -1823,7 +1524,15 @@
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 12,
-    "downstreamCount": 11
+    "downstreamCount": 11,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -1836,7 +1545,7 @@
       "Terraform"
     ],
     "dependencies": [],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -1847,8 +1556,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 130,
-    "downstreamCount": 0
+    "sortOrder": 105,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -1864,15 +1581,23 @@
     "steps": {
       "gen-types": true,
       "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
+      "mapper-fuzzer": true,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go or _identity.go",
     "sortOrder": 11,
-    "downstreamCount": 12
+    "downstreamCount": 12,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -1888,7 +1613,7 @@
       "ComputeDisk",
       "KMSCryptoKey"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -1899,8 +1624,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 299,
-    "downstreamCount": 4
+    "sortOrder": 211,
+    "downstreamCount": 4,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -1919,7 +1652,7 @@
       "IAMServiceAccount",
       "KMSCryptoKey"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -1930,8 +1663,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 28,
-    "downstreamCount": 4
+    "sortOrder": 29,
+    "downstreamCount": 4,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -1946,7 +1687,7 @@
     "dependencies": [
       "ComputeNetwork"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -1958,7 +1699,15 @@
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 14,
-    "downstreamCount": 10
+    "downstreamCount": 10,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -1976,7 +1725,7 @@
       "IAMServiceAccount",
       "Project"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -1987,34 +1736,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 58,
-    "downstreamCount": 1
-  },
-  {
-    "group": "compute",
-    "kind": "ComputeInstanceGroupNamedPort",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 131,
-    "downstreamCount": 0
+    "sortOrder": 60,
+    "downstreamCount": 1,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -2031,19 +1762,27 @@
       "IAMServiceAccount",
       "KMSCryptoKey"
     ],
-    "state": "Not Started",
+    "state": "In Progress",
     "steps": {
       "gen-types": false,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 20,
-    "downstreamCount": 7
+    "downstreamCount": 7,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -2061,41 +1800,23 @@
     "steps": {
       "gen-types": true,
       "identity-reference": false,
-      "mapper-fuzzer": false,
+      "mapper-fuzzer": true,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go or _identity.go",
-    "sortOrder": 29,
-    "downstreamCount": 4
-  },
-  {
-    "group": "compute",
-    "kind": "ComputeMachineImage",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "In Progress",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go or _identity.go",
-    "sortOrder": 132,
-    "downstreamCount": 0
+    "sortOrder": 30,
+    "downstreamCount": 4,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -2109,19 +1830,27 @@
     "dependencies": [
       "Project"
     ],
-    "state": "Not Started",
+    "state": "In Progress",
     "steps": {
       "gen-types": false,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 133,
-    "downstreamCount": 0
+    "sortOrder": 106,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -2134,7 +1863,7 @@
       "Terraform"
     ],
     "dependencies": [],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -2145,36 +1874,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 3,
-    "downstreamCount": 129
-  },
-  {
-    "group": "compute",
-    "kind": "ComputeNetworkEndpoint",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "ComputeInstance",
-      "ComputeNetworkEndpointGroup",
-      "Project"
-    ],
-    "state": "In Progress",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 134,
-    "downstreamCount": 0
+    "sortOrder": 5,
+    "downstreamCount": 136,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -2193,7 +1902,7 @@
     "steps": {
       "gen-types": true,
       "identity-reference": true,
-      "mapper-fuzzer": false,
+      "mapper-fuzzer": true,
       "mocks": false,
       "controller": false,
       "tests": false
@@ -2201,7 +1910,15 @@
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 13,
-    "downstreamCount": 11
+    "downstreamCount": 11,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -2219,15 +1936,23 @@
     "steps": {
       "gen-types": true,
       "identity-reference": false,
-      "mapper-fuzzer": false,
+      "mapper-fuzzer": true,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go or _identity.go",
-    "sortOrder": 135,
-    "downstreamCount": 0
+    "sortOrder": 107,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -2253,35 +1978,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 136,
-    "downstreamCount": 0
-  },
-  {
-    "group": "compute",
-    "kind": "ComputeNetworkFirewallPolicyRule",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "ComputeFirewallPolicy",
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 137,
-    "downstreamCount": 0
+    "sortOrder": 108,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -2299,42 +2005,23 @@
     "steps": {
       "gen-types": true,
       "identity-reference": false,
-      "mapper-fuzzer": false,
+      "mapper-fuzzer": true,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go or _identity.go",
-    "sortOrder": 138,
-    "downstreamCount": 0
-  },
-  {
-    "group": "compute",
-    "kind": "ComputeNetworkPeeringRoutesConfig",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "ComputeNetwork",
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 139,
-    "downstreamCount": 0
+    "sortOrder": 109,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -2353,15 +2040,23 @@
     "steps": {
       "gen-types": true,
       "identity-reference": true,
-      "mapper-fuzzer": false,
-      "mocks": false,
+      "mapper-fuzzer": true,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 140,
-    "downstreamCount": 0
+    "sortOrder": 110,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -2374,7 +2069,7 @@
       "Terraform"
     ],
     "dependencies": [],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -2385,80 +2080,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 59,
-    "downstreamCount": 1
-  },
-  {
-    "group": "compute",
-    "kind": "ComputeOrganizationSecurityPolicy",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "In Progress",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go or _identity.go",
-    "sortOrder": 141,
-    "downstreamCount": 0
-  },
-  {
-    "group": "compute",
-    "kind": "ComputeOrganizationSecurityPolicyAssociation",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 142,
-    "downstreamCount": 0
-  },
-  {
-    "group": "compute",
-    "kind": "ComputeOrganizationSecurityPolicyRule",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 143,
-    "downstreamCount": 0
+    "sortOrder": 61,
+    "downstreamCount": 1,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -2476,42 +2107,23 @@
     "steps": {
       "gen-types": true,
       "identity-reference": false,
-      "mapper-fuzzer": false,
+      "mapper-fuzzer": true,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go or _identity.go",
-    "sortOrder": 144,
-    "downstreamCount": 0
-  },
-  {
-    "group": "compute",
-    "kind": "ComputePerInstanceConfig",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "ComputeInstanceGroupManager",
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 145,
-    "downstreamCount": 0
+    "sortOrder": 111,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -2527,68 +2139,23 @@
     "steps": {
       "gen-types": true,
       "identity-reference": false,
-      "mapper-fuzzer": false,
+      "mapper-fuzzer": true,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go or _identity.go",
-    "sortOrder": 146,
-    "downstreamCount": 0
-  },
-  {
-    "group": "compute",
-    "kind": "ComputeRegionAutoscaler",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "In Progress",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": true,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 147,
-    "downstreamCount": 0
-  },
-  {
-    "group": "compute",
-    "kind": "ComputeRegionDiskResourcePolicyAttachment",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "ComputeDisk",
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 300,
-    "downstreamCount": 0
+    "sortOrder": 112,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -2604,71 +2171,27 @@
       "ComputeSubnetwork",
       "Service"
     ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 148,
-    "downstreamCount": 0
-  },
-  {
-    "group": "compute",
-    "kind": "ComputeRegionPerInstanceConfig",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
     "state": "In Progress",
     "steps": {
-      "gen-types": true,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go or _identity.go",
-    "sortOrder": 149,
-    "downstreamCount": 0
-  },
-  {
-    "group": "compute",
-    "kind": "ComputeRegionSSLPolicy",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
       "gen-types": false,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 150,
-    "downstreamCount": 0
+    "sortOrder": 113,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -2683,7 +2206,7 @@
     "dependencies": [
       "Project"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -2694,8 +2217,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 151,
-    "downstreamCount": 0
+    "sortOrder": 114,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -2711,15 +2242,23 @@
     "steps": {
       "gen-types": true,
       "identity-reference": true,
-      "mapper-fuzzer": false,
-      "mocks": false,
+      "mapper-fuzzer": true,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 152,
-    "downstreamCount": 0
+    "sortOrder": 115,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -2734,7 +2273,7 @@
     "dependencies": [
       "ComputeNetwork"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -2745,8 +2284,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 153,
-    "downstreamCount": 0
+    "sortOrder": 116,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -2761,7 +2308,7 @@
     "dependencies": [
       "ComputeNetwork"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -2773,7 +2320,15 @@
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 22,
-    "downstreamCount": 6
+    "downstreamCount": 6,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -2791,7 +2346,7 @@
       "ComputeSubnetwork",
       "ComputeVPNTunnel"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -2802,8 +2357,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 60,
-    "downstreamCount": 1
+    "sortOrder": 62,
+    "downstreamCount": 1,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -2819,7 +2382,7 @@
       "ComputeRouter",
       "ComputeSubnetwork"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -2830,8 +2393,18 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 154,
-    "downstreamCount": 0
+    "sortOrder": 117,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "computerouternat_controller.go"
+      ]
+    }
   },
   {
     "group": "compute",
@@ -2857,8 +2430,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 155,
-    "downstreamCount": 0
+    "sortOrder": 118,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -2874,15 +2455,23 @@
     "steps": {
       "gen-types": true,
       "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
+      "mapper-fuzzer": true,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go or _identity.go",
-    "sortOrder": 156,
-    "downstreamCount": 0
+    "sortOrder": 119,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -2895,7 +2484,7 @@
       "Terraform"
     ],
     "dependencies": [],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -2906,8 +2495,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 30,
-    "downstreamCount": 4
+    "sortOrder": 31,
+    "downstreamCount": 4,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -2920,7 +2517,7 @@
       "Terraform"
     ],
     "dependencies": [],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -2932,7 +2529,15 @@
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 10,
-    "downstreamCount": 13
+    "downstreamCount": 13,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -2946,19 +2551,27 @@
     "dependencies": [
       "Project"
     ],
-    "state": "Not Started",
+    "state": "In Progress",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
+      "mapper-fuzzer": true,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 40,
-    "downstreamCount": 2
+    "notes": "Missing _reference.go or _identity.go",
+    "sortOrder": 41,
+    "downstreamCount": 2,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -2981,8 +2594,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 157,
-    "downstreamCount": 0
+    "sortOrder": 120,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -3007,8 +2628,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go or _identity.go",
-    "sortOrder": 158,
-    "downstreamCount": 0
+    "sortOrder": 121,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -3026,15 +2655,23 @@
     "steps": {
       "gen-types": true,
       "identity-reference": true,
-      "mapper-fuzzer": false,
+      "mapper-fuzzer": true,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 31,
-    "downstreamCount": 4
+    "sortOrder": 32,
+    "downstreamCount": 4,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -3053,14 +2690,22 @@
       "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 8,
-    "downstreamCount": 23
+    "downstreamCount": 23,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -3078,15 +2723,23 @@
     "steps": {
       "gen-types": true,
       "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
+      "mapper-fuzzer": true,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go or _identity.go",
-    "sortOrder": 41,
-    "downstreamCount": 2
+    "sortOrder": 42,
+    "downstreamCount": 2,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -3104,15 +2757,23 @@
     "steps": {
       "gen-types": true,
       "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
+      "mapper-fuzzer": true,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go or _identity.go",
-    "sortOrder": 42,
-    "downstreamCount": 2
+    "sortOrder": 43,
+    "downstreamCount": 2,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -3128,7 +2789,7 @@
       "ComputeSSLPolicy",
       "ComputeURLMap"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -3139,8 +2800,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 43,
-    "downstreamCount": 2
+    "sortOrder": 44,
+    "downstreamCount": 2,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -3160,15 +2829,23 @@
     "steps": {
       "gen-types": true,
       "identity-reference": false,
-      "mapper-fuzzer": false,
+      "mapper-fuzzer": true,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go or _identity.go",
-    "sortOrder": 159,
-    "downstreamCount": 0
+    "sortOrder": 122,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -3187,15 +2864,23 @@
     "steps": {
       "gen-types": true,
       "identity-reference": false,
-      "mapper-fuzzer": false,
+      "mapper-fuzzer": true,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go or _identity.go",
-    "sortOrder": 160,
-    "downstreamCount": 0
+    "sortOrder": 123,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -3214,15 +2899,23 @@
     "steps": {
       "gen-types": true,
       "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
+      "mapper-fuzzer": true,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go or _identity.go",
-    "sortOrder": 44,
-    "downstreamCount": 2
+    "sortOrder": 45,
+    "downstreamCount": 2,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -3237,7 +2930,7 @@
     "dependencies": [
       "ComputeBackendService"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -3248,8 +2941,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 45,
-    "downstreamCount": 2
+    "sortOrder": 46,
+    "downstreamCount": 2,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -3268,14 +2969,22 @@
       "gen-types": true,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go or _identity.go",
     "sortOrder": 24,
-    "downstreamCount": 5
+    "downstreamCount": 5,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -3291,7 +3000,7 @@
       "ComputeBackendBucket",
       "ComputeBackendService"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -3303,7 +3012,15 @@
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 25,
-    "downstreamCount": 5
+    "downstreamCount": 5,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -3322,15 +3039,23 @@
     "steps": {
       "gen-types": true,
       "identity-reference": true,
-      "mapper-fuzzer": false,
-      "mocks": false,
+      "mapper-fuzzer": true,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 33,
-    "downstreamCount": 3
+    "sortOrder": 34,
+    "downstreamCount": 3,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "compute",
@@ -3350,15 +3075,23 @@
     "steps": {
       "gen-types": true,
       "identity-reference": false,
-      "mapper-fuzzer": false,
+      "mapper-fuzzer": true,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go or _identity.go",
-    "sortOrder": 46,
-    "downstreamCount": 2
+    "sortOrder": 47,
+    "downstreamCount": 2,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "configcontroller",
@@ -3384,8 +3117,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 161,
-    "downstreamCount": 0
+    "sortOrder": 124,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "containeranalysis",
@@ -3397,45 +3138,27 @@
       "DCL"
     ],
     "dependencies": [],
-    "state": "Not Started",
+    "state": "In Progress",
     "steps": {
       "gen-types": false,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 162,
-    "downstreamCount": 0
-  },
-  {
-    "group": "containeranalysis",
-    "kind": "ContainerAnalysisOccurrence",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 163,
-    "downstreamCount": 0
+    "sortOrder": 125,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "containerattached",
@@ -3454,14 +3177,25 @@
       "gen-types": true,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go or _identity.go",
-    "sortOrder": 164,
-    "downstreamCount": 0
+    "sortOrder": 126,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "containerattachedcluster_mappings.go",
+        "mapper.generated.go"
+      ]
+    }
   },
   {
     "group": "container",
@@ -3482,14 +3216,26 @@
       "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 47,
-    "downstreamCount": 2
+    "sortOrder": 48,
+    "downstreamCount": 2,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "containercluster_fuzzer_test.go",
+        "mapper.generated.go",
+        "mapper_manual.go"
+      ]
+    }
   },
   {
     "group": "container",
@@ -3511,14 +3257,25 @@
       "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 165,
-    "downstreamCount": 0
+    "sortOrder": 127,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go",
+        "mappers.go"
+      ]
+    }
   },
   {
     "group": "dlp",
@@ -3544,8 +3301,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 166,
-    "downstreamCount": 0
+    "sortOrder": 128,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "dlp",
@@ -3570,8 +3335,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 61,
-    "downstreamCount": 1
+    "sortOrder": 63,
+    "downstreamCount": 1,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "dlp",
@@ -3598,8 +3371,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 167,
-    "downstreamCount": 0
+    "sortOrder": 129,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "dlp",
@@ -3624,8 +3405,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 168,
-    "downstreamCount": 0
+    "sortOrder": 130,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "dns",
@@ -3640,7 +3429,7 @@
     "dependencies": [
       "ComputeNetwork"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -3651,8 +3440,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 62,
-    "downstreamCount": 1
+    "sortOrder": 64,
+    "downstreamCount": 1,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "dns",
@@ -3667,7 +3464,7 @@
     "dependencies": [
       "ComputeNetwork"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -3678,8 +3475,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 169,
-    "downstreamCount": 0
+    "sortOrder": 131,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "dns",
@@ -3700,67 +3505,22 @@
       "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 170,
-    "downstreamCount": 0
-  },
-  {
-    "group": "dns",
-    "kind": "DNSResponsePolicy",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Direct",
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
       "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 171,
-    "downstreamCount": 0
-  },
-  {
-    "group": "dns",
-    "kind": "DNSResponsePolicyRule",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "In Progress",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": false,
-      "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 172,
-    "downstreamCount": 0
+    "sortOrder": 132,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "datacatalog",
@@ -3785,8 +3545,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 173,
-    "downstreamCount": 0
+    "sortOrder": 133,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "datacatalog",
@@ -3804,15 +3572,23 @@
     "steps": {
       "gen-types": true,
       "identity-reference": true,
-      "mapper-fuzzer": false,
+      "mapper-fuzzer": true,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 63,
-    "downstreamCount": 1
+    "sortOrder": 65,
+    "downstreamCount": 1,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "datafusion",
@@ -3838,8 +3614,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 174,
-    "downstreamCount": 0
+    "sortOrder": 134,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "dataflow",
@@ -3856,7 +3640,7 @@
       "IAMServiceAccount",
       "KMSCryptoKey"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -3867,8 +3651,19 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 175,
-    "downstreamCount": 0
+    "sortOrder": 135,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "dataflowflextemplatejob_controller.go",
+        "mapper.generated.go"
+      ]
+    }
   },
   {
     "group": "dataflow",
@@ -3885,7 +3680,7 @@
       "IAMServiceAccount",
       "KMSCryptoKey"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -3896,8 +3691,19 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 176,
-    "downstreamCount": 0
+    "sortOrder": 136,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go",
+        "mapper.go"
+      ]
+    }
   },
   {
     "group": "dataproc",
@@ -3912,7 +3718,7 @@
     "dependencies": [
       "Project"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -3923,8 +3729,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 177,
-    "downstreamCount": 0
+    "sortOrder": 137,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "dataproc",
@@ -3943,7 +3757,7 @@
       "Project",
       "StorageBucket"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -3955,7 +3769,15 @@
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 23,
-    "downstreamCount": 6
+    "downstreamCount": 6,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "dataproc",
@@ -3973,369 +3795,27 @@
       "Project",
       "StorageBucket"
     ],
-    "state": "Not Started",
+    "state": "In Progress",
     "steps": {
       "gen-types": false,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 178,
-    "downstreamCount": 0
-  },
-  {
-    "group": "datastore",
-    "kind": "DatastoreIndex",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 179,
-    "downstreamCount": 0
-  },
-  {
-    "group": "datastream",
-    "kind": "DatastreamStream",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 180,
-    "downstreamCount": 0
-  },
-  {
-    "group": "deploymentmanager",
-    "kind": "DeploymentManagerDeployment",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 181,
-    "downstreamCount": 0
-  },
-  {
-    "group": "dialogflow",
-    "kind": "DialogflowAgent",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 182,
-    "downstreamCount": 0
-  },
-  {
-    "group": "dialogflowcx",
-    "kind": "DialogflowCXAgent",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 183,
-    "downstreamCount": 0
-  },
-  {
-    "group": "dialogflowcx",
-    "kind": "DialogflowCXEntityType",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 184,
-    "downstreamCount": 0
-  },
-  {
-    "group": "dialogflowcx",
-    "kind": "DialogflowCXFlow",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 185,
-    "downstreamCount": 0
-  },
-  {
-    "group": "dialogflowcx",
-    "kind": "DialogflowCXIntent",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 186,
-    "downstreamCount": 0
-  },
-  {
-    "group": "dialogflowcx",
-    "kind": "DialogflowCXPage",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 187,
-    "downstreamCount": 0
-  },
-  {
-    "group": "dialogflowcx",
-    "kind": "DialogflowCXWebhook",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 188,
-    "downstreamCount": 0
-  },
-  {
-    "group": "dialogflow",
-    "kind": "DialogflowEntityType",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 189,
-    "downstreamCount": 0
-  },
-  {
-    "group": "dialogflow",
-    "kind": "DialogflowFulfillment",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 190,
-    "downstreamCount": 0
-  },
-  {
-    "group": "dialogflow",
-    "kind": "DialogflowIntent",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 191,
-    "downstreamCount": 0
-  },
-  {
-    "group": "documentai",
-    "kind": "DocumentAIProcessorDefaultVersion",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 192,
-    "downstreamCount": 0
+    "sortOrder": 138,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "edgecontainer",
@@ -4350,19 +3830,27 @@
       "KMSCryptoKey",
       "Project"
     ],
-    "state": "Not Started",
+    "state": "In Progress",
     "steps": {
       "gen-types": false,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 48,
-    "downstreamCount": 2
+    "sortOrder": 49,
+    "downstreamCount": 2,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "edgecontainer",
@@ -4378,19 +3866,27 @@
       "KMSCryptoKey",
       "Project"
     ],
-    "state": "Not Started",
+    "state": "In Progress",
     "steps": {
       "gen-types": false,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 193,
-    "downstreamCount": 0
+    "sortOrder": 139,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "edgecontainer",
@@ -4416,8 +3912,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 194,
-    "downstreamCount": 0
+    "sortOrder": 140,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "edgenetwork",
@@ -4431,19 +3935,27 @@
     "dependencies": [
       "Project"
     ],
-    "state": "Not Started",
+    "state": "In Progress",
     "steps": {
       "gen-types": false,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 64,
-    "downstreamCount": 1
+    "sortOrder": 66,
+    "downstreamCount": 1,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "edgenetwork",
@@ -4458,19 +3970,27 @@
       "EdgeNetworkNetwork",
       "Project"
     ],
-    "state": "Not Started",
+    "state": "In Progress",
     "steps": {
       "gen-types": false,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 195,
-    "downstreamCount": 0
+    "sortOrder": 141,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "eventarc",
@@ -4498,8 +4018,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 196,
-    "downstreamCount": 0
+    "sortOrder": 142,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "filestore",
@@ -4524,8 +4052,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 197,
-    "downstreamCount": 0
+    "sortOrder": 143,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "filestore",
@@ -4545,216 +4081,25 @@
       "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 198,
-    "downstreamCount": 0
-  },
-  {
-    "group": "filestore",
-    "kind": "FilestoreSnapshot",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 199,
-    "downstreamCount": 0
-  },
-  {
-    "group": "firebase",
-    "kind": "FirebaseAndroidApp",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "FirebaseProject"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 200,
-    "downstreamCount": 0
-  },
-  {
-    "group": "firebasedatabase",
-    "kind": "FirebaseDatabaseInstance",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 201,
-    "downstreamCount": 0
-  },
-  {
-    "group": "firebasehosting",
-    "kind": "FirebaseHostingChannel",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 202,
-    "downstreamCount": 0
-  },
-  {
-    "group": "firebasehosting",
-    "kind": "FirebaseHostingSite",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 203,
-    "downstreamCount": 0
-  },
-  {
-    "group": "firebase",
-    "kind": "FirebaseProject",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 65,
-    "downstreamCount": 1
-  },
-  {
-    "group": "firebasestorage",
-    "kind": "FirebaseStorageBucket",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 204,
-    "downstreamCount": 0
-  },
-  {
-    "group": "firebase",
-    "kind": "FirebaseWebApp",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 205,
-    "downstreamCount": 0
+    "sortOrder": 144,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go",
+        "mapper.go"
+      ]
+    }
   },
   {
     "group": "firestore",
@@ -4767,7 +4112,7 @@
       "Terraform"
     ],
     "dependencies": [],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -4778,8 +4123,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 206,
-    "downstreamCount": 0
+    "sortOrder": 145,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "resourcemanager",
@@ -4796,14 +4149,25 @@
       "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": true,
+      "mocks": true,
+      "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 1,
-    "downstreamCount": 409
+    "downstreamCount": 452,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go",
+        "mapper.go"
+      ]
+    }
   },
   {
     "group": "gkehub",
@@ -4817,19 +4181,67 @@
     "dependencies": [
       "Project"
     ],
-    "state": "Not Started",
+    "state": "In Progress",
     "steps": {
       "gen-types": false,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 66,
-    "downstreamCount": 1
+    "sortOrder": 67,
+    "downstreamCount": 1,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
+  },
+  {
+    "group": "gkehub",
+    "kind": "GKEHubFeatureMembership",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [
+      "GKEHubFeature",
+      "GKEHubMembership",
+      "IAMServiceAccount",
+      "Project"
+    ],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go or _identity.go",
+    "sortOrder": 146,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "gkehubfeaturemembership_controller.go",
+        "mappings.go"
+      ]
+    }
   },
   {
     "group": "gkehub",
@@ -4841,141 +4253,27 @@
       "DCL"
     ],
     "dependencies": [],
-    "state": "Not Started",
+    "state": "In Progress",
     "steps": {
       "gen-types": false,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 49,
-    "downstreamCount": 2
-  },
-  {
-    "group": "healthcare",
-    "kind": "HealthcareConsentStore",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 207,
-    "downstreamCount": 0
-  },
-  {
-    "group": "healthcare",
-    "kind": "HealthcareDICOMStore",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 208,
-    "downstreamCount": 0
-  },
-  {
-    "group": "healthcare",
-    "kind": "HealthcareDataset",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 209,
-    "downstreamCount": 0
-  },
-  {
-    "group": "healthcare",
-    "kind": "HealthcareFHIRStore",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 210,
-    "downstreamCount": 0
-  },
-  {
-    "group": "healthcare",
-    "kind": "HealthcareHL7V2Store",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 211,
-    "downstreamCount": 0
+    "sortOrder": 50,
+    "downstreamCount": 2,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "iam",
@@ -5000,8 +4298,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 212,
-    "downstreamCount": 0
+    "sortOrder": 147,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "iam",
@@ -5024,8 +4330,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go or _identity.go",
-    "sortOrder": 213,
-    "downstreamCount": 0
+    "sortOrder": 148,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "iam",
@@ -5048,8 +4362,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 214,
-    "downstreamCount": 0
+    "sortOrder": 149,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "iam",
@@ -5063,21 +4385,30 @@
     ],
     "dependencies": [
       "IAMServiceAccount",
+      "SQLInstance",
       "ServiceIdentity"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": true,
-      "mocks": true,
+      "mocks": false,
       "controller": true,
-      "tests": true
+      "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go or _identity.go",
-    "sortOrder": 215,
-    "downstreamCount": 0
+    "sortOrder": 150,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "iam",
@@ -5092,16 +4423,27 @@
     "state": "In Progress",
     "steps": {
       "gen-types": true,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
       "mocks": false,
       "controller": true,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go or _identity.go",
-    "sortOrder": 216,
-    "downstreamCount": 0
+    "sortOrder": 151,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "iampartialpolicy_controller.go",
+        "mappings.go"
+      ]
+    }
   },
   {
     "group": "iam",
@@ -5114,6 +4456,7 @@
     ],
     "dependencies": [
       "IAMServiceAccount",
+      "SQLInstance",
       "ServiceIdentity"
     ],
     "state": "In Progress",
@@ -5121,14 +4464,22 @@
       "gen-types": true,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go or _identity.go",
-    "sortOrder": 217,
-    "downstreamCount": 0
+    "sortOrder": 152,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "iam",
@@ -5145,14 +4496,24 @@
       "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 6,
-    "downstreamCount": 55
+    "downstreamCount": 61,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mappers.go"
+      ]
+    }
   },
   {
     "group": "iam",
@@ -5171,14 +4532,25 @@
       "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 218,
-    "downstreamCount": 0
+    "sortOrder": 153,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.go",
+        "mappers.go"
+      ]
+    }
   },
   {
     "group": "iam",
@@ -5201,8 +4573,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 67,
-    "downstreamCount": 1
+    "sortOrder": 68,
+    "downstreamCount": 1,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "iam",
@@ -5227,8 +4607,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 219,
-    "downstreamCount": 0
+    "sortOrder": 154,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "iam",
@@ -5253,8 +4641,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 68,
-    "downstreamCount": 1
+    "sortOrder": 69,
+    "downstreamCount": 1,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "iam",
@@ -5280,8 +4676,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 220,
-    "downstreamCount": 0
+    "sortOrder": 155,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "iap",
@@ -5308,8 +4712,16 @@
       "gcpAPIDeprecated": true,
       "notes": "IAP Brand APIs are deprecated. Context can be found at https://docs.cloud.google.com/iap/docs/deprecations and https://docs.cloud.google.com/iap/docs/deprecations/migrate-oauth-client."
     },
-    "sortOrder": 301,
-    "downstreamCount": 1
+    "sortOrder": 212,
+    "downstreamCount": 1,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "iap",
@@ -5334,8 +4746,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 221,
-    "downstreamCount": 0
+    "sortOrder": 156,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "identityplatform",
@@ -5360,60 +4780,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 222,
-    "downstreamCount": 0
-  },
-  {
-    "group": "identityplatform",
-    "kind": "IdentityPlatformDefaultSupportedIDPConfig",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 223,
-    "downstreamCount": 0
-  },
-  {
-    "group": "identityplatform",
-    "kind": "IdentityPlatformInboundSAMLConfig",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 224,
-    "downstreamCount": 0
+    "sortOrder": 157,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "identityplatform",
@@ -5436,34 +4812,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 225,
-    "downstreamCount": 0
-  },
-  {
-    "group": "identityplatform",
-    "kind": "IdentityPlatformProjectDefaultConfig",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 226,
-    "downstreamCount": 0
+    "sortOrder": 158,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "identityplatform",
@@ -5486,60 +4844,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 69,
-    "downstreamCount": 1
-  },
-  {
-    "group": "identityplatform",
-    "kind": "IdentityPlatformTenantDefaultSupportedIDPConfig",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 227,
-    "downstreamCount": 0
-  },
-  {
-    "group": "identityplatform",
-    "kind": "IdentityPlatformTenantInboundSAMLConfig",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 228,
-    "downstreamCount": 0
+    "sortOrder": 70,
+    "downstreamCount": 1,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "identityplatform",
@@ -5564,8 +4878,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 229,
-    "downstreamCount": 0
+    "sortOrder": 159,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "kms",
@@ -5580,7 +4902,7 @@
     "dependencies": [
       "KMSKeyRing"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -5591,32 +4913,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 5,
-    "downstreamCount": 126
-  },
-  {
-    "group": "kms",
-    "kind": "KMSCryptoKeyVersion",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "In Progress",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 230,
-    "downstreamCount": 0
+    "sortOrder": 4,
+    "downstreamCount": 140,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "kms",
@@ -5629,7 +4935,7 @@
       "Terraform"
     ],
     "dependencies": [],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -5640,56 +4946,19 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 4,
-    "downstreamCount": 128
-  },
-  {
-    "group": "kms",
-    "kind": "KMSKeyRingImportJob",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "In Progress",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 231,
-    "downstreamCount": 0
-  },
-  {
-    "group": "kms",
-    "kind": "KMSSecretCiphertext",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "In Progress",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 232,
-    "downstreamCount": 0
+    "sortOrder": 3,
+    "downstreamCount": 142,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "kmskeyring_controller.go",
+        "kmskeyring_mappers.go"
+      ]
+    }
   },
   {
     "group": "logging",
@@ -5705,7 +4974,7 @@
       "Folder",
       "Project"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -5716,8 +4985,20 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 34,
-    "downstreamCount": 3
+    "sortOrder": 35,
+    "downstreamCount": 3,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "logginglogbucket_controller.go",
+        "mapper.generated.go",
+        "mapper.go"
+      ]
+    }
   },
   {
     "group": "logging",
@@ -5733,6 +5014,45 @@
       "Folder",
       "Project"
     ],
+    "state": "In Progress",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "",
+    "sortOrder": 160,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "logginglogexclusion_controller.go",
+        "mapper.generated.go",
+        "mapper.go"
+      ]
+    }
+  },
+  {
+    "group": "logging",
+    "kind": "LoggingLogMetric",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [
+      "LoggingLogBucket",
+      "Project"
+    ],
     "state": "Completed",
     "steps": {
       "gen-types": true,
@@ -5744,8 +5064,18 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 233,
-    "downstreamCount": 0
+    "sortOrder": 161,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go"
+      ]
+    }
   },
   {
     "group": "logging",
@@ -5765,7 +5095,7 @@
       "PubSubTopic",
       "StorageBucket"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -5776,8 +5106,20 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 234,
-    "downstreamCount": 0
+    "sortOrder": 162,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "logginglogsink_controller.go",
+        "mapper.generated.go",
+        "mapper.go"
+      ]
+    }
   },
   {
     "group": "logging",
@@ -5794,7 +5136,7 @@
       "Project",
       "StorageBucket"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -5805,34 +5147,20 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 235,
-    "downstreamCount": 0
-  },
-  {
-    "group": "mlengine",
-    "kind": "MLEngineModel",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 236,
-    "downstreamCount": 0
+    "sortOrder": 163,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "logginglogview_controller.go",
+        "mapper.generated.go",
+        "mapper.go"
+      ]
+    }
   },
   {
     "group": "memcache",
@@ -5846,19 +5174,27 @@
     "dependencies": [
       "ComputeNetwork"
     ],
-    "state": "Not Started",
+    "state": "In Progress",
     "steps": {
       "gen-types": false,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 237,
-    "downstreamCount": 0
+    "sortOrder": 164,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "monitoring",
@@ -5867,6 +5203,7 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [],
@@ -5874,15 +5211,66 @@
     "steps": {
       "gen-types": true,
       "identity-reference": true,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 70,
-    "downstreamCount": 1
+    "sortOrder": 71,
+    "downstreamCount": 1,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "alertpolicy_mappings.go",
+        "mapper.generated.go",
+        "monitoringalertpolicy_controller.go"
+      ]
+    }
+  },
+  {
+    "group": "monitoring",
+    "kind": "MonitoringDashboard",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [
+      "MonitoringAlertPolicy",
+      "Project"
+    ],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "",
+    "sortOrder": 165,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "dashboard_generated.mappings.go",
+        "mapper.generated.go",
+        "monitoringdashboard_controller.go"
+      ]
+    }
   },
   {
     "group": "monitoring",
@@ -5901,14 +5289,25 @@
       "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 71,
-    "downstreamCount": 1
+    "sortOrder": 72,
+    "downstreamCount": 1,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go",
+        "mappers.go"
+      ]
+    }
   },
   {
     "group": "monitoring",
@@ -5927,14 +5326,25 @@
       "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 238,
-    "downstreamCount": 0
+    "sortOrder": 166,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go",
+        "metricdescriptor_mappings.go"
+      ]
+    }
   },
   {
     "group": "monitoring",
@@ -5951,14 +5361,25 @@
       "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 239,
-    "downstreamCount": 0
+    "sortOrder": 167,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go",
+        "monitoredproject_mappings.go"
+      ]
+    }
   },
   {
     "group": "monitoring",
@@ -5975,14 +5396,24 @@
       "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 240,
-    "downstreamCount": 0
+    "sortOrder": 168,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go"
+      ]
+    }
   },
   {
     "group": "monitoring",
@@ -6001,14 +5432,24 @@
       "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 72,
-    "downstreamCount": 1
+    "sortOrder": 73,
+    "downstreamCount": 1,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go"
+      ]
+    }
   },
   {
     "group": "monitoring",
@@ -6023,19 +5464,27 @@
       "MonitoringService",
       "Project"
     ],
-    "state": "Not Started",
+    "state": "In Progress",
     "steps": {
       "gen-types": false,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 241,
-    "downstreamCount": 0
+    "sortOrder": 169,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "monitoring",
@@ -6055,14 +5504,24 @@
       "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 242,
-    "downstreamCount": 0
+    "sortOrder": 170,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go"
+      ]
+    }
   },
   {
     "group": "networkconnectivity",
@@ -6076,19 +5535,27 @@
     "dependencies": [
       "Project"
     ],
-    "state": "Not Started",
+    "state": "In Progress",
     "steps": {
       "gen-types": false,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 73,
-    "downstreamCount": 1
+    "sortOrder": 74,
+    "downstreamCount": 1,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "networkconnectivity",
@@ -6103,19 +5570,27 @@
       "NetworkConnectivityHub",
       "Project"
     ],
-    "state": "Not Started",
+    "state": "In Progress",
     "steps": {
       "gen-types": false,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 243,
-    "downstreamCount": 0
+    "sortOrder": 171,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "networksecurity",
@@ -6134,14 +5609,22 @@
       "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 244,
-    "downstreamCount": 0
+    "sortOrder": 172,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "networksecurity",
@@ -6166,8 +5649,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 245,
-    "downstreamCount": 0
+    "sortOrder": 173,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "networksecurity",
@@ -6181,97 +5672,27 @@
     "dependencies": [
       "Project"
     ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 246,
-    "downstreamCount": 0
-  },
-  {
-    "group": "networkservices",
-    "kind": "NetworkServicesEdgeCacheKeyset",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 247,
-    "downstreamCount": 0
-  },
-  {
-    "group": "networkservices",
-    "kind": "NetworkServicesEdgeCacheOrigin",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 248,
-    "downstreamCount": 0
-  },
-  {
-    "group": "networkservices",
-    "kind": "NetworkServicesEdgeCacheService",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
     "state": "In Progress",
     "steps": {
-      "gen-types": true,
-      "identity-reference": true,
+      "gen-types": false,
+      "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 249,
-    "downstreamCount": 0
+    "sortOrder": 174,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "networkservices",
@@ -6296,8 +5717,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 250,
-    "downstreamCount": 0
+    "sortOrder": 175,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "networkservices",
@@ -6323,8 +5752,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 251,
-    "downstreamCount": 0
+    "sortOrder": 176,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "networkservices",
@@ -6339,7 +5776,7 @@
     "dependencies": [
       "Project"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -6350,8 +5787,19 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 252,
-    "downstreamCount": 0
+    "sortOrder": 177,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mappers.go",
+        "networkservicesgateway_controller.go"
+      ]
+    }
   },
   {
     "group": "networkservices",
@@ -6360,25 +5808,36 @@
     "controllerType": "DCL",
     "defaultController": "DCL",
     "supportedControllers": [
-      "DCL"
+      "DCL",
+      "Direct"
     ],
     "dependencies": [
       "Project",
       "Service"
     ],
-    "state": "Not Started",
+    "state": "In Progress",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 253,
-    "downstreamCount": 0
+    "sortOrder": 178,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "networkserviceshttproute_controller.go"
+      ]
+    }
   },
   {
     "group": "networkservices",
@@ -6392,19 +5851,27 @@
     "dependencies": [
       "Project"
     ],
-    "state": "Not Started",
+    "state": "In Progress",
     "steps": {
       "gen-types": false,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 254,
-    "downstreamCount": 0
+    "sortOrder": 179,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "networkservices",
@@ -6430,8 +5897,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 255,
-    "downstreamCount": 0
+    "sortOrder": 180,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "networkservices",
@@ -6457,8 +5932,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 256,
-    "downstreamCount": 0
+    "sortOrder": 181,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "osconfig",
@@ -6477,14 +5960,25 @@
       "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 257,
-    "downstreamCount": 0
+    "sortOrder": 182,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go",
+        "mapper_manual.go"
+      ]
+    }
   },
   {
     "group": "osconfig",
@@ -6509,58 +6003,18 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 258,
-    "downstreamCount": 0
-  },
-  {
-    "group": "osconfig",
-    "kind": "OSConfigPatchDeployment",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 259,
-    "downstreamCount": 0
-  },
-  {
-    "group": "oslogin",
-    "kind": "OSLoginSSHPublicKey",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 260,
-    "downstreamCount": 0
+    "sortOrder": 183,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go"
+      ]
+    }
   },
   {
     "group": "privateca",
@@ -6575,7 +6029,7 @@
     "dependencies": [
       "Project"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -6585,9 +6039,20 @@
       "tests": true
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 50,
-    "downstreamCount": 2
+    "notes": "Missing _reference.go or _identity.go",
+    "sortOrder": 51,
+    "downstreamCount": 2,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go",
+        "privatecacapool_controller.go"
+      ]
+    }
   },
   {
     "group": "privateca",
@@ -6604,35 +6069,6 @@
       "PrivateCACertificateTemplate",
       "Project"
     ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 261,
-    "downstreamCount": 0
-  },
-  {
-    "group": "privateca",
-    "kind": "PrivateCACertificateAuthority",
-    "version": "v1beta1",
-    "controllerType": "DCL",
-    "defaultController": "DCL",
-    "supportedControllers": [
-      "DCL"
-    ],
-    "dependencies": [
-      "KMSCryptoKey",
-      "PrivateCACAPool",
-      "Project",
-      "StorageBucket"
-    ],
     "state": "In Progress",
     "steps": {
       "gen-types": true,
@@ -6644,8 +6080,61 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 74,
-    "downstreamCount": 1
+    "sortOrder": 184,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go",
+        "mapper.go"
+      ]
+    }
+  },
+  {
+    "group": "privateca",
+    "kind": "PrivateCACertificateAuthority",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL",
+      "Direct"
+    ],
+    "dependencies": [
+      "KMSCryptoKey",
+      "PrivateCACAPool",
+      "Project",
+      "StorageBucket"
+    ],
+    "state": "In Progress",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "",
+    "sortOrder": 75,
+    "downstreamCount": 1,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go",
+        "mapper.go",
+        "privatecacertificateauthority_controller.go"
+      ]
+    }
   },
   {
     "group": "privateca",
@@ -6660,7 +6149,7 @@
     "dependencies": [
       "Project"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -6671,8 +6160,20 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 75,
-    "downstreamCount": 1
+    "sortOrder": 76,
+    "downstreamCount": 1,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go",
+        "mapper.go",
+        "privatecacertificatetemplate_controller.go"
+      ]
+    }
   },
   {
     "group": "resourcemanager",
@@ -6691,14 +6192,25 @@
       "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 2,
-    "downstreamCount": 404
+    "downstreamCount": 447,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go",
+        "mapper.go"
+      ]
+    }
   },
   {
     "group": "pubsublite",
@@ -6712,12 +6224,12 @@
     "dependencies": [
       "Project"
     ],
-    "state": "Not Started",
+    "state": "In Progress",
     "steps": {
       "gen-types": false,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
@@ -6727,68 +6239,16 @@
       "gcpAPIDeprecated": true,
       "notes": "Pub/Sub Lite is deprecated. Please find more details at https://docs.cloud.google.com/pubsub/lite/docs/release-notes#June_17_2024"
     },
-    "sortOrder": 302,
-    "downstreamCount": 0
-  },
-  {
-    "group": "pubsublite",
-    "kind": "PubSubLiteSubscription",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "edgeCases": {
-      "gcpAPIDeprecated": true,
-      "notes": "Pub/Sub Lite is deprecated. Please find more details at https://docs.cloud.google.com/pubsub/lite/docs/release-notes#June_17_2024"
-    },
-    "sortOrder": 303,
-    "downstreamCount": 0
-  },
-  {
-    "group": "pubsublite",
-    "kind": "PubSubLiteTopic",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "edgeCases": {
-      "gcpAPIDeprecated": true,
-      "notes": "Pub/Sub Lite is deprecated. Please find more details at https://docs.cloud.google.com/pubsub/lite/docs/release-notes#June_17_2024"
-    },
-    "sortOrder": 304,
-    "downstreamCount": 0
+    "sortOrder": 213,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "pubsub",
@@ -6803,7 +6263,7 @@
     "dependencies": [
       "Project"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -6815,7 +6275,18 @@
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 17,
-    "downstreamCount": 8
+    "downstreamCount": 8,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go",
+        "pubsubschema_controller.go"
+      ]
+    }
   },
   {
     "group": "pubsub",
@@ -6831,7 +6302,7 @@
       "PubSubTopic",
       "StorageBucket"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -6842,8 +6313,19 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 51,
-    "downstreamCount": 2
+    "sortOrder": 52,
+    "downstreamCount": 2,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go",
+        "pubsubsubscription_controller.go"
+      ]
+    }
   },
   {
     "group": "pubsub",
@@ -6859,7 +6341,7 @@
       "KMSCryptoKey",
       "PubSubSchema"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -6871,7 +6353,18 @@
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 21,
-    "downstreamCount": 7
+    "downstreamCount": 7,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go",
+        "pubsubtopic_controller.go"
+      ]
+    }
   },
   {
     "group": "recaptchaenterprise",
@@ -6886,7 +6379,7 @@
     "dependencies": [
       "Project"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -6897,8 +6390,19 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 262,
-    "downstreamCount": 0
+    "sortOrder": 185,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "key_mappers.go",
+        "recaptchaenterprisekey_controller.go"
+      ]
+    }
   },
   {
     "group": "redis",
@@ -6913,7 +6417,7 @@
     "dependencies": [
       "ComputeNetwork"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -6924,8 +6428,19 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 263,
-    "downstreamCount": 0
+    "sortOrder": 186,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go",
+        "redisinstance_controller.go"
+      ]
+    }
   },
   {
     "group": "resourcemanager",
@@ -6950,8 +6465,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 264,
-    "downstreamCount": 0
+    "sortOrder": 187,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "resourcemanager",
@@ -6977,8 +6500,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 265,
-    "downstreamCount": 0
+    "sortOrder": 188,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "run",
@@ -6996,19 +6527,27 @@
       "Project",
       "StorageBucket"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": true,
       "mocks": true,
       "controller": true,
-      "tests": true
+      "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 266,
-    "downstreamCount": 0
+    "sortOrder": 189,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "run",
@@ -7024,19 +6563,27 @@
       "IAMServiceAccount",
       "Project"
     ],
-    "state": "Not Started",
+    "state": "In Progress",
     "steps": {
       "gen-types": false,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 267,
-    "downstreamCount": 0
+    "sortOrder": 190,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "sql",
@@ -7047,20 +6594,66 @@
     "supportedControllers": [
       "Terraform"
     ],
-    "dependencies": [],
-    "state": "Not Started",
+    "dependencies": [
+      "SQLInstance"
+    ],
+    "state": "In Progress",
     "steps": {
       "gen-types": false,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 268,
-    "downstreamCount": 0
+    "sortOrder": 191,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
+  },
+  {
+    "group": "sql",
+    "kind": "SQLInstance",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [
+      "ComputeNetwork",
+      "KMSCryptoKey",
+      "StorageBucket"
+    ],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go or _identity.go",
+    "sortOrder": 26,
+    "downstreamCount": 5,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "sql",
@@ -7071,7 +6664,9 @@
     "supportedControllers": [
       "Terraform"
     ],
-    "dependencies": [],
+    "dependencies": [
+      "SQLInstance"
+    ],
     "state": "Not Started",
     "steps": {
       "gen-types": false,
@@ -7083,8 +6678,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 269,
-    "downstreamCount": 0
+    "sortOrder": 192,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "sql",
@@ -7095,20 +6698,30 @@
     "supportedControllers": [
       "Terraform"
     ],
-    "dependencies": [],
-    "state": "Not Started",
+    "dependencies": [
+      "SQLInstance"
+    ],
+    "state": "In Progress",
     "steps": {
       "gen-types": false,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 270,
-    "downstreamCount": 0
+    "sortOrder": 193,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "secretmanager",
@@ -7123,7 +6736,7 @@
     "dependencies": [
       "KMSCryptoKey"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -7134,8 +6747,20 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 52,
-    "downstreamCount": 2
+    "sortOrder": 53,
+    "downstreamCount": 2,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go",
+        "secret_mapping.go",
+        "secretmanagersecret_controller.go"
+      ]
+    }
   },
   {
     "group": "secretmanager",
@@ -7150,67 +6775,30 @@
     "dependencies": [
       "SecretManagerSecret"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": true,
       "mocks": true,
       "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 271,
-    "downstreamCount": 0
-  },
-  {
-    "group": "securitycenter",
-    "kind": "SecurityCenterNotificationConfig",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 272,
-    "downstreamCount": 0
-  },
-  {
-    "group": "securitycenter",
-    "kind": "SecurityCenterSource",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 273,
-    "downstreamCount": 0
+    "sortOrder": 194,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go",
+        "secretmanagersecretversion_controller.go"
+      ]
+    }
   },
   {
     "group": "serviceusage",
@@ -7225,7 +6813,7 @@
     "dependencies": [
       "Project"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -7237,7 +6825,18 @@
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 9,
-    "downstreamCount": 15
+    "downstreamCount": 15,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go",
+        "mapper.go"
+      ]
+    }
   },
   {
     "group": "servicedirectory",
@@ -7253,7 +6852,7 @@
       "ComputeNetwork",
       "Service"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -7264,8 +6863,20 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 274,
-    "downstreamCount": 0
+    "sortOrder": 195,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go",
+        "mapper.go",
+        "servicedirectoryendpoint_controller.go"
+      ]
+    }
   },
   {
     "group": "servicedirectory",
@@ -7280,7 +6891,7 @@
     "dependencies": [
       "Project"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -7291,8 +6902,20 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 76,
-    "downstreamCount": 1
+    "sortOrder": 77,
+    "downstreamCount": 1,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go",
+        "mapper.go",
+        "servicedirectorynamespace_controller.go"
+      ]
+    }
   },
   {
     "group": "servicedirectory",
@@ -7307,7 +6930,7 @@
     "dependencies": [
       "ServiceDirectoryNamespace"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -7318,8 +6941,20 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 275,
-    "downstreamCount": 0
+    "sortOrder": 196,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go",
+        "mapper.go",
+        "servicedirectoryservice_controller.go"
+      ]
+    }
   },
   {
     "group": "serviceusage",
@@ -7328,6 +6963,7 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [
@@ -7337,15 +6973,25 @@
     "steps": {
       "gen-types": true,
       "identity-reference": true,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 53,
-    "downstreamCount": 2
+    "sortOrder": 54,
+    "downstreamCount": 2,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go"
+      ]
+    }
   },
   {
     "group": "servicenetworking",
@@ -7359,45 +7005,27 @@
     "dependencies": [
       "ComputeNetwork"
     ],
-    "state": "Not Started",
+    "state": "In Progress",
     "steps": {
       "gen-types": false,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 276,
-    "downstreamCount": 0
-  },
-  {
-    "group": "serviceusage",
-    "kind": "ServiceUsageConsumerQuotaOverride",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 277,
-    "downstreamCount": 0
+    "sortOrder": 197,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "sourcerepo",
@@ -7422,8 +7050,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 278,
-    "downstreamCount": 0
+    "sortOrder": 198,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "spanner",
@@ -7438,19 +7074,27 @@
       "KMSCryptoKey",
       "SpannerInstance"
     ],
-    "state": "Not Started",
+    "state": "In Progress",
     "steps": {
       "gen-types": false,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 77,
-    "downstreamCount": 1
+    "sortOrder": 78,
+    "downstreamCount": 1,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "spanner",
@@ -7463,7 +7107,7 @@
       "Terraform"
     ],
     "dependencies": [],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -7474,8 +7118,18 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 54,
-    "downstreamCount": 2
+    "sortOrder": 55,
+    "downstreamCount": 2,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "spannerinstance_controller.go"
+      ]
+    }
   },
   {
     "group": "storage",
@@ -7494,15 +7148,25 @@
     "steps": {
       "gen-types": true,
       "identity-reference": true,
-      "mapper-fuzzer": false,
-      "mocks": false,
+      "mapper-fuzzer": true,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 7,
-    "downstreamCount": 40
+    "downstreamCount": 42,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": true,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go"
+      ]
+    }
   },
   {
     "group": "storage",
@@ -7516,19 +7180,27 @@
     "dependencies": [
       "StorageBucket"
     ],
-    "state": "Not Started",
+    "state": "In Progress",
     "steps": {
       "gen-types": false,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 279,
-    "downstreamCount": 0
+    "sortOrder": 199,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "storage",
@@ -7553,34 +7225,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 280,
-    "downstreamCount": 0
-  },
-  {
-    "group": "storage",
-    "kind": "StorageHMACKey",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 281,
-    "downstreamCount": 0
+    "sortOrder": 200,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "storage",
@@ -7594,45 +7248,27 @@
     "dependencies": [
       "StorageBucket"
     ],
-    "state": "Not Started",
+    "state": "In Progress",
     "steps": {
       "gen-types": false,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 282,
-    "downstreamCount": 0
-  },
-  {
-    "group": "storagetransfer",
-    "kind": "StorageTransferAgentPool",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 283,
-    "downstreamCount": 0
+    "sortOrder": 201,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "storagetransfer",
@@ -7657,34 +7293,16 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 284,
-    "downstreamCount": 0
-  },
-  {
-    "group": "tpu",
-    "kind": "TPUNode",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 285,
-    "downstreamCount": 0
+    "sortOrder": 202,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "tags",
@@ -7709,9 +7327,20 @@
       "tests": true
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 286,
-    "downstreamCount": 0
+    "notes": "Missing _reference.go or _identity.go",
+    "sortOrder": 203,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go",
+        "tagslocationtagbinding_controller.go"
+      ]
+    }
   },
   {
     "group": "tags",
@@ -7726,7 +7355,7 @@
     "dependencies": [
       "TagsTagValue"
     ],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -7737,8 +7366,19 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 287,
-    "downstreamCount": 0
+    "sortOrder": 204,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go",
+        "tagstagbinding_controller.go"
+      ]
+    }
   },
   {
     "group": "tags",
@@ -7751,7 +7391,7 @@
       "Terraform"
     ],
     "dependencies": [],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -7762,8 +7402,19 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 288,
-    "downstreamCount": 0
+    "sortOrder": 205,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go",
+        "tagstagkey_controller.go"
+      ]
+    }
   },
   {
     "group": "tags",
@@ -7776,7 +7427,7 @@
       "Terraform"
     ],
     "dependencies": [],
-    "state": "Completed",
+    "state": "In Progress",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
@@ -7787,8 +7438,19 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 55,
-    "downstreamCount": 2
+    "sortOrder": 56,
+    "downstreamCount": 2,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mapper.generated.go",
+        "tagstagvalue_controller.go"
+      ]
+    }
   },
   {
     "group": "vpcaccess",
@@ -7803,19 +7465,27 @@
       "ComputeNetwork",
       "Project"
     ],
-    "state": "Not Started",
+    "state": "In Progress",
     "steps": {
       "gen-types": false,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 289,
-    "downstreamCount": 0
+    "sortOrder": 206,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "vertexai",
@@ -7835,14 +7505,24 @@
       "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 290,
-    "downstreamCount": 0
+    "sortOrder": 207,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": true,
+      "has_std_reference": true,
+      "has_std_mapper": false,
+      "has_std_fuzzer": true,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": [
+        "mappers.go"
+      ]
+    }
   },
   {
     "group": "vertexai",
@@ -7858,67 +7538,27 @@
       "KMSCryptoKey",
       "Project"
     ],
-    "state": "Not Started",
+    "state": "In Progress",
     "steps": {
       "gen-types": false,
       "identity-reference": false,
       "mapper-fuzzer": false,
-      "mocks": false,
+      "mocks": true,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 291,
-    "downstreamCount": 0
-  },
-  {
-    "group": "vertexai",
-    "kind": "VertexAIFeaturestoreEntityType",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 292,
-    "downstreamCount": 0
-  },
-  {
-    "group": "vertexai",
-    "kind": "VertexAIFeaturestoreEntityTypeFeature",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 293,
-    "downstreamCount": 0
+    "sortOrder": 208,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   },
   {
     "group": "vertexai",
@@ -7943,59 +7583,15 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 294,
-    "downstreamCount": 0
-  },
-  {
-    "group": "vertexai",
-    "kind": "VertexAIIndexEndpoint",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 295,
-    "downstreamCount": 0
-  },
-  {
-    "group": "vertexai",
-    "kind": "VertexAITensorboard",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 296,
-    "downstreamCount": 0
+    "sortOrder": 209,
+    "downstreamCount": 0,
+    "artifacts": {
+      "has_std_identity": false,
+      "has_std_reference": false,
+      "has_std_mapper": false,
+      "has_std_fuzzer": false,
+      "non_std_id_ref_files": [],
+      "non_std_mapper_fuzzer_files": []
+    }
   }
 ]

--- a/dev/migration-tracker/generate_data.py
+++ b/dev/migration-tracker/generate_data.py
@@ -68,6 +68,61 @@ def get_implemented_controllers(direct_dir=None):
                 implemented_controllers.add(file)
     return implemented_controllers
 
+def get_test_fixtures_and_http_logs(basic_dir=None):
+    kinds_with_fixtures = set()
+    # kinds_with_migration_fixtures tracks resources with fixtures that do NOT explicitly set
+    # the 'reconciler: direct' annotation in create.yaml. These fixtures are used by the E2E
+    # migration test suite (TestMigrationToDirect) to verify transitioning a resource from a legacy
+    # controller (Terraform/DCL) to the Direct controller.
+    kinds_with_migration_fixtures = set()
+    kinds_with_mock_log = set()
+    if basic_dir is None:
+        basic_dir = os.path.join(SCRIPT_DIR, "../../pkg/test/resourcefixture/testdata/basic")
+    if not os.path.exists(basic_dir):
+        return kinds_with_fixtures, kinds_with_migration_fixtures, kinds_with_mock_log
+    for root, _, files in os.walk(basic_dir):
+        if 'create.yaml' in files:
+            create_path = os.path.join(root, 'create.yaml')
+            try:
+                with open(create_path, 'r', encoding='utf-8') as f:
+                    content = f.read()
+                    is_direct_first = ('alpha.cnrm.cloud.google.com/reconciler: direct' in content or 
+                                       'cnrm.cloud.google.com/reconciler: direct' in content)
+                    for doc in yaml.safe_load_all(content):
+                        if doc and isinstance(doc, dict) and 'kind' in doc:
+                            k = doc['kind']
+                            kinds_with_fixtures.add(k)
+                            if not is_direct_first:
+                                kinds_with_migration_fixtures.add(k)
+                            if '_http_mock.log' in files:
+                                kinds_with_mock_log.add(k)
+            except Exception:
+                pass
+    return kinds_with_fixtures, kinds_with_migration_fixtures, kinds_with_mock_log
+
+def get_implemented_direct_go_files(direct_dir=None):
+    if direct_dir is None:
+        direct_dir = os.path.normpath(os.path.join(SCRIPT_DIR, "../../pkg/controller/direct"))
+    group_direct_files = defaultdict(list)
+    if not os.path.exists(direct_dir):
+        return group_direct_files
+    for root, _, files in os.walk(direct_dir):
+        rel = os.path.relpath(root, direct_dir).lower().split(os.sep)
+        group = rel[0] if rel and rel[0] != '.' else ''
+        if not group:
+            continue
+        for f in files:
+            f_lower = f.lower()
+            if f_lower.endswith('.go'):
+                path = os.path.join(root, f)
+                try:
+                    with open(path, 'r', encoding='utf-8') as file_obj:
+                        content = file_obj.read()
+                        group_direct_files[group].append((f_lower, content))
+                except Exception:
+                    pass
+    return group_direct_files
+
 def build_dependency_graph(crds_dir=None):
     if crds_dir is None:
         crds_dir = os.path.join(SCRIPT_DIR, "../../config/crds/resources")
@@ -75,8 +130,9 @@ def build_dependency_graph(crds_dir=None):
     dependencies = defaultdict(set)
     crd_docs = []
     
+    crd_versions = {}
     if not os.path.exists(crds_dir):
-        return dependencies, known_kinds
+        return dependencies, known_kinds, crd_versions
         
     for filename in os.listdir(crds_dir):
         if not filename.endswith(".yaml"):
@@ -90,6 +146,7 @@ def build_dependency_graph(crds_dir=None):
                         kind = doc["spec"]["names"]["kind"]
                         group = doc["spec"]["group"]
                         known_kinds[kind] = group
+                        crd_versions[kind] = [v["name"] for v in doc["spec"]["versions"]]
             except Exception:
                 pass
 
@@ -127,13 +184,15 @@ def build_dependency_graph(crds_dir=None):
                     if matched_kind and matched_kind in known_kinds and matched_kind != kind:
                         dependencies[kind].add(matched_kind)
 
-    return dependencies, known_kinds
+    return dependencies, known_kinds, crd_versions
 
 def parse_data(config_file_path, apis_dir, crds_dir, direct_dir=None):
     if direct_dir is None:
         direct_dir = os.path.join(SCRIPT_DIR, "../../pkg/controller/direct")
     resources = {}
     
+    dependencies, known_kinds, crd_versions = build_dependency_graph(crds_dir)
+
     # Load existing data to preserve manual updates
     existing_resources = {}
     data_json_path = os.path.join(SCRIPT_DIR, 'data.json')
@@ -145,6 +204,21 @@ def parse_data(config_file_path, apis_dir, crds_dir, direct_dir=None):
         except Exception as e:
             print(f"Warning: Could not load existing data.json: {e}", file=sys.stderr)
             
+    # Overrides for brownfield resources that were originally generated via tf2crd or dcl2crd (supporting v1beta1),
+    # but had their legacy controller entries cleaned up from static_config.go after 100% direct completion.
+    # These must be tracked in data.json as completed brownfield migrations so we do not lose track of completed work.
+    COMPLETED_BROWNFIELD_OVERRIDES = {
+        "AlloyDBInstance": "alloydb",
+        "CertificateManagerDNSAuthorization": "certificatemanager",
+        "CloudIdentityGroup": "cloudidentity",
+        "CloudIdentityMembership": "cloudidentity",
+        "ComputeFirewallPolicyRule": "compute",
+        "GKEHubFeatureMembership": "gkehub",
+        "LoggingLogMetric": "logging",
+        "MonitoringDashboard": "monitoring",
+        "SQLInstance": "sql",
+    }
+
     with open(config_file_path, 'r') as f:
         config_lines = f.readlines()
         
@@ -168,8 +242,12 @@ def parse_data(config_file_path, apis_dir, crds_dir, direct_dir=None):
                 ctrls_raw = supported_ctrls_match.group(1)
                 supported = re.findall(r'k8s\.ReconcilerType([A-Za-z]+)', ctrls_raw)
             
-            # Skip if it only supports Direct (born direct or fully migrated and old controllers removed)
-            if len(supported) == 1 and supported[0] == 'Direct':
+            # Skip if it only supports Direct (born direct greenfield resources), UNLESS it is a known fully-migrated brownfield resource override
+            if len(supported) == 1 and supported[0] == 'Direct' and kind not in COMPLETED_BROWNFIELD_OVERRIDES:
+                continue
+
+            # Skip if it is v1alpha1-only (only has v1alpha1 version in CRD)
+            if kind in crd_versions and all(ver == 'v1alpha1' for ver in crd_versions[kind]) and kind not in COMPLETED_BROWNFIELD_OVERRIDES:
                 continue
                 
             resources[kind] = create_default_resource(kind, group)
@@ -178,20 +256,16 @@ def parse_data(config_file_path, apis_dir, crds_dir, direct_dir=None):
             # Restore existing manual fields if they exist
             if kind in existing_resources:
                 existing = existing_resources[kind]
-                resources[kind]['state'] = existing.get('state', resources[kind]['state'])
                 resources[kind]['notes'] = existing.get('notes', resources[kind]['notes'])
                 resources[kind]['mocksLastRefreshed'] = existing.get('mocksLastRefreshed', resources[kind]['mocksLastRefreshed'])
                 if 'edgeCases' in existing:
                     resources[kind]['edgeCases'] = existing['edgeCases']
-                if 'steps' in existing:
-                    for step, val in existing['steps'].items():
-                        resources[kind]['steps'][step] = val
             
             if default_ctrl_match:
                 resources[kind]['defaultController'] = default_ctrl_match.group(1)
                 resources[kind]['controllerType'] = default_ctrl_match.group(1)
                 
-            if 'Direct' in supported:
+            if resources[kind]['defaultController'] == 'Direct' or kind in COMPLETED_BROWNFIELD_OVERRIDES:
                 resources[kind]['state'] = 'Completed'
                 resources[kind]['steps'] = {
                     "gen-types": True,
@@ -201,10 +275,32 @@ def parse_data(config_file_path, apis_dir, crds_dir, direct_dir=None):
                     "controller": True,
                     "tests": True
                 }
+            else:
+                if resources[kind]['state'] == 'Completed':
+                    resources[kind]['state'] = 'Not Started'
 
-    dependencies, known_kinds = build_dependency_graph(crds_dir)
+    # Ensure all COMPLETED_BROWNFIELD_OVERRIDES exist in resources even if missing from static_config.go
+    for kind, group in COMPLETED_BROWNFIELD_OVERRIDES.items():
+        if kind not in resources:
+            resources[kind] = create_default_resource(kind, group)
+            resources[kind]['supportedControllers'] = ['Direct']
+            resources[kind]['defaultController'] = 'Direct'
+            resources[kind]['controllerType'] = 'Direct'
+            resources[kind]['state'] = 'Completed'
+            resources[kind]['steps'] = {
+                "gen-types": True,
+                "identity-reference": True,
+                "mapper-fuzzer": True,
+                "mocks": True,
+                "controller": True,
+                "tests": True
+            }
+
+    dependencies, known_kinds, _ = build_dependency_graph(crds_dir)
     implemented_types = get_implemented_types(apis_dir)
     implemented_controllers = get_implemented_controllers(direct_dir)
+    kinds_with_fixtures, kinds_with_migration_fixtures, kinds_with_mock_log = get_test_fixtures_and_http_logs()
+    group_direct_files = get_implemented_direct_go_files(direct_dir)
 
     # Calculate topological sort order and downstream count
     nodes = set(known_kinds.keys())
@@ -257,56 +353,79 @@ def parse_data(config_file_path, apis_dir, crds_dir, direct_dir=None):
     for kind, res in resources.items():
         res['sortOrder'] = topo_order.get(kind, 9999)
         res['downstreamCount'] = downstream_counts.get(kind, 0)
-        
+        group_lower = res['group'].lower()
+        kind_lower = kind.lower()
+
         if kind in dependencies:
             valid_deps = [dep for dep in dependencies[kind] if dep in resources]
             res['dependencies'] = sorted(valid_deps)
 
+        has_std_identity = False
+        has_std_reference = False
+        non_std_id_ref_files = []
+
         if kind in implemented_types:
             res['steps']['gen-types'] = True
-            has_identity_reference = False
-            has_mapper = False
+
+            std_id_filename = f"{kind_lower}_identity.go"
+            std_ref_filename = f"{kind_lower}_reference.go"
+
             for filepath in implemented_types[kind]:
                 dirpath = os.path.dirname(filepath)
                 filename = os.path.basename(filepath)
                 prefix = filename.replace("_types.go", "")
-                
-                possible_id_ref_names = [
-                    f"{prefix}_reference.go",
-                    f"{prefix}_identity.go",
-                    f"{kind.lower()}_reference.go",
-                    f"{kind.lower()}_identity.go",
-                ]
-                
-                for name in possible_id_ref_names:
-                    if os.path.exists(os.path.join(dirpath, name)):
-                        has_identity_reference = True
-                        break
-                
-                possible_mapper_names = [
-                    f"{prefix}_mapper.go",
-                    f"{prefix}_fuzzer.go",
-                    f"{kind.lower()}_mapper.go",
-                    f"{kind.lower()}_fuzzer.go",
-                ]
-                for name in possible_mapper_names:
-                    if os.path.exists(os.path.join(dirpath, name)):
-                        has_mapper = True
-                        break
 
-                if has_identity_reference and has_mapper:
-                    break
-            
-            if has_identity_reference:
+                if os.path.exists(os.path.join(dirpath, std_id_filename)):
+                    has_std_identity = True
+
+                if os.path.exists(os.path.join(dirpath, std_ref_filename)):
+                    has_std_reference = True
+
+                # Check for non-standard / shared identity or reference files in apis/<group>/<version>/
+                possible_alt_names = [f"{prefix}_identity.go", "identity.go", f"{prefix}_reference.go", "reference.go"]
+                for alt_name in possible_alt_names:
+                    if alt_name not in (std_id_filename, std_ref_filename):
+                        alt_path = os.path.join(dirpath, alt_name)
+                        if os.path.exists(alt_path):
+                            non_std_id_ref_files.append(alt_name)
+
+            if has_std_identity and has_std_reference:
                 res['steps']['identity-reference'] = True
                 if res.get('notes') in ('Missing _reference.go', 'Missing _reference.go or _identity.go'):
                     res['notes'] = ''
             else:
                 res['notes'] = 'Missing _reference.go or _identity.go'
                 res['steps']['identity-reference'] = False
-            
-            if has_mapper:
-                res['steps']['mapper-fuzzer'] = True
+
+        std_mapper_file = os.path.join(SCRIPT_DIR, "../../pkg/controller/direct", group_lower, f"{kind_lower}_mapper.go")
+        std_fuzzer_file = os.path.join(SCRIPT_DIR, "../../pkg/controller/direct", group_lower, f"{kind_lower}_fuzzer.go")
+
+        has_mapper = os.path.exists(std_mapper_file)
+        has_fuzzer = os.path.exists(std_fuzzer_file)
+
+        if has_mapper and has_fuzzer:
+            res['steps']['mapper-fuzzer'] = True
+        else:
+            res['steps']['mapper-fuzzer'] = False
+
+        # Compute artifact metadata for architectural gap analysis
+        non_std_files = []
+        if group_lower in group_direct_files:
+            mapper_regex = re.compile(rf'\b({re.escape(kind)}(Spec|Status|ObservedState)?(_)?(ToProto|FromProto|ToKRM|FromKRM|Mapper))\b')
+            fuzzer_regex = re.compile(rf'\b(Fuzz{re.escape(kind)}|{re.escape(kind)}Fuzzer)\b')
+            for filename, content in group_direct_files[group_lower]:
+                if filename not in (f'{kind_lower}_mapper.go', f'{kind_lower}_fuzzer.go'):
+                    if mapper_regex.search(content) or fuzzer_regex.search(content):
+                        non_std_files.append(filename)
+
+        res['artifacts'] = {
+            'has_std_identity': has_std_identity,
+            'has_std_reference': has_std_reference,
+            'has_std_mapper': has_mapper,
+            'has_std_fuzzer': has_fuzzer,
+            'non_std_id_ref_files': sorted(list(set(non_std_id_ref_files))),
+            'non_std_mapper_fuzzer_files': sorted(list(set(non_std_files))),
+        }
 
         possible_controller_names = [
             f"{kind.lower()}_controller.go",
@@ -321,7 +440,17 @@ def parse_data(config_file_path, apis_dir, crds_dir, direct_dir=None):
         for ctrl_name in possible_controller_names:
             if ctrl_name in implemented_controllers:
                 res['steps']['controller'] = True
+                # Controller completion implies types, identity/ref, and mapper/fuzzer prerequisites
+                res['steps']['gen-types'] = True
+                res['steps']['identity-reference'] = True
+                res['steps']['mapper-fuzzer'] = True
                 break
+
+        if kind in kinds_with_mock_log:
+            res['steps']['mocks'] = True
+
+        if 'Direct' in res.get('supportedControllers', []) and kind in kinds_with_migration_fixtures:
+            res['steps']['tests'] = True
 
         if res['state'] != 'Completed' and any(res['steps'].values()):
             res['state'] = 'In Progress'
@@ -347,6 +476,18 @@ def parse_data(config_file_path, apis_dir, crds_dir, direct_dir=None):
     for kind in deprecated_kinds:
         resources[kind]['sortOrder'] = current_order
         current_order += 1
+
+    # Report any resources removed from data.json after this run
+    if existing_resources:
+        old_kinds = set(existing_resources.keys())
+        new_kinds = set(resources.keys())
+        removed_kinds = old_kinds - new_kinds
+        if removed_kinds:
+            print(f"\n[NOTICE] {len(removed_kinds)} resource(s) removed from tracked resource list after this run:", file=sys.stderr)
+            for k in sorted(removed_kinds):
+                grp = existing_resources[k].get('group', 'unknown')
+                print(f"   - {k} (Group: {grp})", file=sys.stderr)
+            print("", file=sys.stderr)
 
     return list(resources.values())
 

--- a/dev/migration-tracker/generate_md.py
+++ b/dev/migration-tracker/generate_md.py
@@ -22,6 +22,30 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 DATA_JSON_PATH = os.path.join(SCRIPT_DIR, 'data.json')
 OUTPUT_MD_PATH = os.path.join(SCRIPT_DIR, 'MIGRATION_STATUS.md')
 
+def get_next_step(r):
+    steps = r.get("steps", {})
+    if not steps.get("gen-types"):
+        return "Types"
+    if not steps.get("identity-reference"):
+        return "Identity/Ref"
+    if not steps.get("mapper-fuzzer"):
+        return "Mapper/Fuzz"
+    if not steps.get("mocks"):
+        return "Mocks"
+    if not steps.get("controller"):
+        return "Controller"
+    if not steps.get("tests"):
+        return "Tests"
+
+    supported_ctrls = r.get("supportedControllers", [])
+    if "Direct" not in supported_ctrls:
+        return "Register Direct Controller"
+
+    if r.get("defaultController") != "Direct":
+        return "Default to Direct Controller"
+
+    return "-"
+
 def main():
     # Refresh data.json if generate_data.py exists
     gen_script = os.path.join(SCRIPT_DIR, 'generate_data.py')
@@ -66,7 +90,7 @@ def main():
         else:
             by_group[grp]['not_started'] += 1
 
-    sorted_groups = sorted(by_group.items(), key=lambda x: (-x[1]['total'], x[0]))
+    sorted_groups = sorted(by_group.items(), key=lambda x: x[0])
 
     unmigrated = [r for r in data if r.get('state') != 'Completed' and not r.get('edgeCases', {}).get('gcpAPIDeprecated')]
     unmigrated.sort(key=lambda x: x.get('sortOrder', 9999))
@@ -113,23 +137,21 @@ def main():
     md.append('')
     md.append('---')
     md.append('')
-    md.append('## Top Priority Unmigrated Resources (Dependency Order)')
-
-
-    md.append('| Topo Order | Group | Kind | State | Types | Ref/ID | Controller | Downstream Count |')
-    md.append('| :---: | :--- | :--- | :---: | :---: | :---: | :---: | :---: |')
+    md.append('## Unmigrated Resources with Most Dependencies')
+    md.append('')
+    md.append('This section lists unmigrated brownfield resources ordered by their downstream dependency count (topological order). Resources with higher downstream counts are referenced by many other KCC resources, making them critical candidates to unblock migration pipelines.')
+    md.append('')
+    md.append('| Topo Order | Group | Kind | Downstream Dependents | State | Next Step |')
+    md.append('| :---: | :--- | :--- | :---: | :---: | :--- |')
 
     for r in unmigrated[:25]:
         order = r.get('sortOrder', '-')
         grp = r.get('group', '-')
         knd = r.get('kind', '-')
         st = r.get('state', '-')
-        # Omit 'No' and output empty string '' when false for readability purposes
-        st_types = 'Yes' if r.get('steps', {}).get('gen-types') else ''
-        st_ref = 'Yes' if r.get('steps', {}).get('identity-reference') else ''
-        st_ctrl = 'Yes' if r.get('steps', {}).get('controller') else ''
+        next_step = get_next_step(r)
         downstream = r.get('downstreamCount', 0)
-        md.append(f'| #{order} | `{grp}` | `{knd}` | **{st}** | {st_types} | {st_ref} | {st_ctrl} | `{downstream}` |')
+        md.append(f'| #{order} | `{grp}` | `{knd}` | `{downstream}` | **{st}** | `{next_step}` |')
 
     md.append('')
     md.append('---')

--- a/dev/migration-tracker/generate_md.py
+++ b/dev/migration-tracker/generate_md.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import re
+import subprocess
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+DATA_JSON_PATH = os.path.join(SCRIPT_DIR, 'data.json')
+OUTPUT_MD_PATH = os.path.join(SCRIPT_DIR, 'MIGRATION_STATUS.md')
+
+def main():
+    # Refresh data.json if generate_data.py exists
+    gen_script = os.path.join(SCRIPT_DIR, 'generate_data.py')
+    if os.path.exists(gen_script):
+        try:
+            subprocess.run(['python3', gen_script], check=True)
+        except Exception as e:
+            print(f"Warning: Could not auto-refresh data.json: {e}")
+
+    if not os.path.exists(DATA_JSON_PATH):
+        print(f"Error: {DATA_JSON_PATH} not found.")
+        return
+
+    with open(DATA_JSON_PATH, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    total = len(data)
+    completed = sum(1 for r in data if r.get('state') == 'Completed')
+    direct_ctrl_completed = sum(1 for r in data if 'Direct' in r.get('supportedControllers', []) and r.get('defaultController') != 'Direct')
+    in_progress = sum(1 for r in data if r.get('state') == 'In Progress')
+    not_started = sum(1 for r in data if r.get('state') == 'Not Started')
+
+    pct_completed = round(completed / total * 100, 1) if total else 0
+    pct_direct_ctrl = round(direct_ctrl_completed / total * 100, 1) if total else 0
+    pct_in_progress = round(in_progress / total * 100, 1) if total else 0
+    pct_not_started = round(not_started / total * 100, 1) if total else 0
+
+    steps_keys = ['gen-types', 'identity-reference', 'mapper-fuzzer', 'mocks', 'controller', 'tests']
+    steps_count = {k: sum(1 for r in data if r.get('steps', {}).get(k)) for k in steps_keys}
+
+    by_group = {}
+    for r in data:
+        grp = r.get('group', 'unknown')
+        if grp not in by_group:
+            by_group[grp] = {'total': 0, 'completed': 0, 'in_progress': 0, 'not_started': 0}
+        by_group[grp]['total'] += 1
+        st = r.get('state', 'Not Started')
+        if st == 'Completed':
+            by_group[grp]['completed'] += 1
+        elif st == 'In Progress':
+            by_group[grp]['in_progress'] += 1
+        else:
+            by_group[grp]['not_started'] += 1
+
+    sorted_groups = sorted(by_group.items(), key=lambda x: (-x[1]['total'], x[0]))
+
+    unmigrated = [r for r in data if r.get('state') != 'Completed' and not r.get('edgeCases', {}).get('gcpAPIDeprecated')]
+    unmigrated.sort(key=lambda x: x.get('sortOrder', 9999))
+
+    md = []
+    md.append('# KCC Brownfield Resource Migration Dashboard')
+    md.append('')
+    md.append('> [!NOTE]')
+    md.append('> For scope details, generator script usage, and tracking methodology, see [README.md](./README.md).')
+    md.append('')
+    md.append('## Migration Overview')
+    md.append('')
+    md.append('| Metric | Count | Percentage | Progress Bar |')
+    md.append('| :--- | :---: | :---: | :--- |')
+    bar_c = '#' * int(pct_completed / 5) + '-' * (20 - int(pct_completed / 5))
+    bar_d = '#' * int(pct_direct_ctrl / 5) + '-' * (20 - int(pct_direct_ctrl / 5))
+    bar_p = '#' * int(pct_in_progress / 5) + '-' * (20 - int(pct_in_progress / 5))
+    bar_n = '#' * int(pct_not_started / 5) + '-' * (20 - int(pct_not_started / 5))
+    md.append(f'| **Completed** | **{completed}** | `{pct_completed}%` | `{bar_c}` |')
+    md.append(f'| **In Progress** | **{in_progress}** | `{pct_in_progress}%` | `{bar_p}` |')
+    md.append(f'| &nbsp;&nbsp;&nbsp;&nbsp;-> *Direct Controller Enabled* | *{direct_ctrl_completed}* | `{pct_direct_ctrl}%` | `{bar_d}` |')
+    md.append(f'| **Not Started** | **{not_started}** | `{pct_not_started}%` | `{bar_n}` |')
+    md.append(f'| **Total Resources** | **{total}** | `100.0%` | |')
+    md.append('')
+    md.append('---')
+    md.append('')
+    md.append('## Step Implementation Status')
+    md.append('')
+    md.append('| Step Name | Description | Completed Resources | Progress |')
+    md.append('| :--- | :--- | :---: | :---: |')
+    for step in steps_keys:
+        cnt = steps_count[step]
+        pct = round(cnt / total * 100, 1) if total else 0
+        desc = {
+            'gen-types': 'Direct Go API Types in `apis/`',
+            'identity-reference': 'Identity and Ref logic (`*_identity.go` AND `*_reference.go`)',
+            'mapper-fuzzer': 'Proto/KRM Mappers AND Fuzzers in `pkg/controller/direct/`',
+            'controller': 'Direct Controller implementation (`*_controller.go`, not all registered in static config)',
+            'mocks': 'MockGCP alignment and golden logs (`_http_mock.log`)',
+            'tests': 'E2E migration test suite (`TestMigrationToDirect`)'
+        }.get(step, '')
+        md.append(f'| `{step}` | {desc} | **{cnt}** / {total} | `{pct}%` |')
+
+    md.append('')
+    md.append('---')
+    md.append('')
+    md.append('## Top Priority Unmigrated Resources (Dependency Order)')
+
+
+    md.append('| Topo Order | Group | Kind | State | Types | Ref/ID | Controller | Downstream Count |')
+    md.append('| :---: | :--- | :--- | :---: | :---: | :---: | :---: | :---: |')
+
+    for r in unmigrated[:25]:
+        order = r.get('sortOrder', '-')
+        grp = r.get('group', '-')
+        knd = r.get('kind', '-')
+        st = r.get('state', '-')
+        # Omit 'No' and output empty string '' when false for readability purposes
+        st_types = 'Yes' if r.get('steps', {}).get('gen-types') else ''
+        st_ref = 'Yes' if r.get('steps', {}).get('identity-reference') else ''
+        st_ctrl = 'Yes' if r.get('steps', {}).get('controller') else ''
+        downstream = r.get('downstreamCount', 0)
+        md.append(f'| #{order} | `{grp}` | `{knd}` | **{st}** | {st_types} | {st_ref} | {st_ctrl} | `{downstream}` |')
+
+    md.append('')
+    md.append('---')
+    md.append('## Resource Migration Progress by Service / Group')
+    md.append('')
+    md.append('<details>')
+    md.append('<summary>Click to expand progress by service / group</summary>')
+    md.append('')
+    md.append('| Group | Total | Completed | In Progress | Not Started | % Complete |')
+    md.append('| :--- | :---: | :---: | :---: | :---: | :---: |')
+    for grp, stats in sorted_groups:
+        tot = stats['total']
+        comp = stats['completed']
+        inp = stats['in_progress']
+        ns = stats['not_started']
+        pct = round(comp / tot * 100, 1) if tot else 0
+        md.append(f'| `{grp}` | {tot} | {comp} | {inp} | {ns} | `{pct}%` |')
+
+    md.append('')
+    md.append('</details>')
+    md.append('')
+    md.append('---')
+    md.append('')
+    md.append('## Full Resource Migration Registry')
+    md.append('')
+    md.append('<details>')
+    md.append('<summary>Click to expand all resources</summary>')
+    md.append('')
+    md.append('| Group | Kind | Controller Type | State | Types | Identity/Ref | Mapper/Fuzz | Mocks | Controller | Tests | Direct Registered | Direct Defaulted |')
+    md.append('| :--- | :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |')
+
+    sorted_data = sorted(data, key=lambda x: (x.get('group', ''), x.get('kind', '')))
+    for r in sorted_data:
+        grp = r.get('group', '-')
+        knd = r.get('kind', '-')
+        ctrl = r.get('controllerType', r.get('defaultController', '-'))
+        st = r.get('state', '-')
+        s = r.get('steps', {})
+        # Omit 'No' and output empty string '' when false for readability purposes
+        s1 = 'Yes' if s.get('gen-types') else ''
+        s2 = 'Yes' if s.get('identity-reference') else ''
+        s3 = 'Yes' if s.get('mapper-fuzzer') else ''
+        s4 = 'Yes' if s.get('mocks') else ''
+        s5 = 'Yes' if s.get('controller') else ''
+        s6 = 'Yes' if s.get('tests') else ''
+        reg = 'Yes' if 'Direct' in r.get('supportedControllers', []) else ''
+        def_ctrl = 'Yes' if r.get('defaultController') == 'Direct' or r.get('controllerType') == 'Direct' else ''
+        md.append(f'| `{grp}` | `{knd}` | `{ctrl}` | **{st}** | {s1} | {s2} | {s3} | {s4} | {s5} | {s6} | {reg} | {def_ctrl} |')
+
+    md.append('')
+    md.append('</details>')
+    md.append('')
+    md.append('---')
+    md.append('')
+    md.append('## Architectural Analysis: Controller vs. Artifact Gaps')
+    md.append('')
+    md.append('<details>')
+    md.append('<summary>Click to expand architectural analysis of controller artifact gaps</summary>')
+    md.append('')
+    md.append('> [!NOTE]')
+    md.append('> A completed **Direct Controller** (`controller == Yes`) requires API types, identity/reference resolution, and resource mapping to function. For tracking purposes, controller completion implies prerequisite step completion.')
+    md.append('> Below is an architectural analysis of brownfield resources with controllers implemented (`controller == Yes`) that lack separate standalone identity/reference or mapper/fuzzer artifact files.')
+    md.append('')
+
+    ctrl_resources = [r for r in data if r.get('steps', {}).get('controller') == True]
+
+    missing_id_ref = []
+    missing_mf = []
+    misplaced_artifacts = []
+
+    missing_id_ref_all = []
+    for r in data:
+        kind = r['kind']
+        group = r['group']
+        art = r.get('artifacts', {})
+        has_id = art.get('has_std_identity', False)
+        has_ref = art.get('has_std_reference', False)
+        has_ctrl = r.get('steps', {}).get('controller') == True
+        non_std_id_ref = art.get('non_std_id_ref_files', [])
+        if not (has_id and has_ref) and (has_ctrl or non_std_id_ref):
+            missing_id_ref_all.append((group, kind, non_std_id_ref, has_ctrl))
+
+    for r in ctrl_resources:
+        kind = r['kind']
+        group = r['group']
+        art = r.get('artifacts', {})
+
+        has_mapper = art.get('has_std_mapper', False)
+        has_fuzzer = art.get('has_std_fuzzer', False)
+        non_std_files = art.get('non_std_mapper_fuzzer_files', [])
+
+        if not (has_mapper and has_fuzzer):
+            missing_mf.append((group, kind))
+            if non_std_files:
+                misplaced_artifacts.append((group, kind, non_std_files))
+
+    md.append('### 1. Controllers / Types Missing Standalone Identity / Reference Files')
+    md.append('')
+    md.append(f'The following **{len(missing_id_ref_all)}** resources lack separate standard `<kind_lower>_identity.go` or `<kind_lower>_reference.go` files in `apis/`:')
+    md.append('')
+    md.append('| Group | Kind | Reason / Actual File Placement |')
+    md.append('| :--- | :--- | :--- |')
+    for g, k, alt_files, has_ctrl in sorted(missing_id_ref_all, key=lambda x: (x[0], x[1])):
+        if alt_files:
+            note = f"Shared file placement: {', '.join([f'`{f}`' for f in alt_files])}"
+        elif 'IAM' in k:
+            note = 'Custom IAM policy reference handling integrated into controller'
+        else:
+            note = 'Direct identity/ref logic embedded in controller adapter'
+        md.append(f'| `{g}` | `{k}` | {note} |')
+
+    md.append('')
+    md.append('### 2. Controllers Missing Standalone Mapper or Fuzzer Files')
+    md.append('')
+    md.append(f'The following **{len(missing_mf)}** resources have direct controllers implemented, but lack separate standalone mapper (`*_mapper.go`) AND fuzzer (`*_fuzzer.go`) files in `pkg/controller/direct/<group>/`:')
+    md.append('')
+    md.append('<details>')
+    md.append(f'<summary>Click to expand all {len(missing_mf)} resources lacking strict standalone mapper/fuzzer files</summary>')
+    md.append('')
+    md.append('| Group | Kind |')
+    md.append('| :--- | :--- |')
+    for g, k in sorted(missing_mf, key=lambda x: (x[0], x[1])):
+        md.append(f'| `{g}` | `{k}` |')
+    md.append('')
+    md.append('</details>')
+    md.append('')
+    md.append('### 3. Misplaced / Non-Standard Artifact Placements')
+    md.append('')
+    md.append(f'The following **{len(misplaced_artifacts)}** resources have mapper/fuzzer symbols implemented, but placed in non-standard or shared filenames rather than standard `<kind_lower>_mapper.go` / `<kind_lower>_fuzzer.go` files:')
+    md.append('')
+    md.append('<details>')
+    md.append(f'<summary>Click to expand all {len(misplaced_artifacts)} resources with misplaced artifact files</summary>')
+    md.append('')
+    md.append('| Group | Kind | Actual File Locations |')
+    md.append('| :--- | :--- | :--- |')
+    for g, k, files in sorted(misplaced_artifacts, key=lambda x: (x[0], x[1])):
+        files_str = ', '.join([f'`{f}`' for f in files])
+        md.append(f'| `{g}` | `{k}` | {files_str} |')
+    md.append('')
+    md.append('</details>')
+    md.append('')
+    md.append('</details>')
+    md.append('')
+
+    with open(OUTPUT_MD_PATH, 'w', encoding='utf-8') as f:
+        f.write('\n'.join(md))
+
+    print(f"Generated markdown dashboard at: {OUTPUT_MD_PATH}")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
### BRIEF Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
### Summary

This PR refactors the brownfield controller migration tracking system under `dev/migration-tracker/` and updates the automated GitHub Actions workflow to keep `data.json` and `MIGRATION_STATUS.md` in sync.

The latest migration status can be found at https://github.com/maqiuyujoyce/k8s-config-connector/blob/0e8eb50f290df325185ef7a32fe4aca05542c30b/dev/migration-tracker/MIGRATION_STATUS.md.

#### Key Changes

1. **Refactored Migration Tracker Pipeline (`generate_data.py` & `generate_md.py`)**:
   - **Unified Disk Scanning (`generate_data.py`)**: Consolidated all filesystem scanning, regex symbol matching, artifact metadata collection (`has_std_identity`, `has_std_reference`, `has_std_mapper`, `has_std_fuzzer`), and topological dependency calculations into `generate_data.py`, serializing artifact metadata directly into `data.json`.
   - **Strict Standard Naming**: Enforced strict naming checks for standard `<kind_lower>_identity.go` and `<kind_lower>_reference.go` files.
   - **Pure Markdown Renderer (`generate_md.py`)**: Updated `generate_md.py` to read purely from `data.json` without re-scanning disk, producing clean, clutter-free Markdown tables (`Yes` / empty cell) and 100% ASCII progress bars.
   - **Architectural Analysis**: Added analysis sections in `MIGRATION_STATUS.md` highlighting resources that lack standalone identity/reference files or place mappers/fuzzers in non-standard/shared filenames (e.g. `SpannerInstance`, `AccessContextManagerServicePerimeterResource`).

2. **Updated Weekly Automation Workflow (`.github/workflows/migration-tracker.yaml`)**:
   - **Weekly Schedule**: Updated cron trigger to run weekly every Sunday at 13:17 UTC (`17 13 * * 0`).
   - **Complete Generator Sync**: Configured workflow to run `generate_md.py`, updating both `data.json` and `MIGRATION_STATUS.md` together.
   - **Execution Log PR Description**: Configured `gh pr create` and `gh pr edit` to use `--body-file /tmp/generator_output.log` so Python generator execution logs serve directly as the PR description.
   - **Reviewer Assignment & Single Open PR**: Automatically requests review from `@maqiuyujoyce` and closes old stale PRs to ensure strictly one open automation PR exists at a time.

3. **Documentation Update**:
   - Updated `dev/migration-tracker/README.md` to document the 2-stage architecture, data flow, and workflow automation.

#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
