### PR TITLE
cli: add namespace and current status to preview summary report

### DIFF
--- a/pkg/cli/cmd/preview/README.md
+++ b/pkg/cli/cmd/preview/README.md
@@ -72,7 +72,7 @@ config-connector preview --gcp-qps 10 --gcp-burst 10
 
 The tool generates several files:
 
--   `preview-report-<timestamp>`: A summary table showing the Group, Kind, Name, and the reconciliation status/diffs for both the default and alternative runs.
+-   `preview-report-<timestamp>`: A summary table showing the Group, Kind, Namespace, Name, and the reconciliation status/diffs for both the default and alternative runs.
 -   `preview-report-<timestamp>-detail`: (Generated if errors occur) A JSON file containing detailed information about "Unhealthy" resources.
 -   `preview-report-<timestamp>-full-default`: (Generated if `--full-report` is set) Detailed event log for the default run.
 -   `preview-report-<timestamp>-full-alternative`: (Generated if `--full-report` is set) Detailed event log for the alternative run.
@@ -81,13 +81,14 @@ The tool generates several files:
 
 The summary report contains the following columns:
 
--   **GROUP/KIND/NAME**: Identifies the resource.
+-   **GROUP/KIND/NAMESPACE/NAME**: Identifies the resource.
+-   **CURRENT-STATUS**: The current status/reason of the resource in the cluster (e.g., `UpToDate`, `UpdateFailed`).
 -   **DEFAULT-CONTROLLER**: The controller used in the baseline run (e.g., `Terraform`, `Direct`).
 -   **DEFAULT-RESULT**: `HEALTHY` or `UNHEALTHY`.
--   **DEFAULT-DIFFS**: Fields that had diffs during reconciliation.
 -   **ALTERNATIVE-CONTROLLER**: The alternative controller being tested.
 -   **ALTERNATIVE-RESULT**: `HEALTHY`, `UNHEALTHY`, or `Missing` (if the alternative controller failed to pick up the resource).
--   **ALTERNATIVE-DIFFS**: Fields that had diffs during the alternative run.
+-   **DEFAULT-DIFFS**: Fields that had diffs during reconciliation in the default run.
+-   **ALTERNATIVE-DIFFS**: Fields that had diffs during reconciliation in the alternative run.
 
 ---
 

--- a/pkg/cli/preview/recorder.go
+++ b/pkg/cli/preview/recorder.go
@@ -77,7 +77,8 @@ func (r *Recorder) GetRemainResourcesCount() int {
 
 // objectInfo holds the activity from reconciling the objects
 type objectInfo struct {
-	events []event
+	currentStatus string
+	events        []event
 }
 
 type event struct {
@@ -204,6 +205,9 @@ func (r *Recorder) recordReconcileStart(ctx context.Context, u *unstructured.Uns
 	}
 
 	info := r.getObjectInfo(gknn)
+	if info.currentStatus == "" || info.currentStatus == "N/A" {
+		info.currentStatus = extractCurrentStatus(u)
+	}
 	info.events = append(info.events, event{
 		eventType:      EventTypeReconcileStart,
 		reconcilerType: t,
@@ -426,18 +430,58 @@ func (r *Recorder) PreloadGKNN(ctx context.Context, config *rest.Config, namespa
 				}
 			}
 			for _, resource := range resources.Items {
-				r.ReconciledResources[GKNN{
+				gknn := GKNN{
 					Group:     gvr.Group,
 					Kind:      resource.GetKind(),
 					Namespace: resource.GetNamespace(),
 					Name:      resource.GetName(),
-				}] = false
+				}
+				r.ReconciledResources[gknn] = false
+				status := extractCurrentStatus(&resource)
+				info := r.getObjectInfo(gknn)
+				info.currentStatus = status
 			}
 			r.RemainResourcesCount += len(resources.Items)
 		}
 	}
 	log.V(0).Info("Successfully preloaded the list of resources to reconcile", "count", r.RemainResourcesCount)
 	return nil
+}
+
+// extractCurrentStatus extracts the current status/reason from a resource's status.conditions.
+func extractCurrentStatus(u *unstructured.Unstructured) string {
+	if u == nil {
+		return "N/A"
+	}
+	conditions, found, err := unstructured.NestedSlice(u.Object, "status", "conditions")
+	if err != nil || !found || len(conditions) == 0 {
+		return "N/A"
+	}
+	for _, condRaw := range conditions {
+		condMap, ok := condRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if condType, _ := condMap["type"].(string); condType == "Ready" {
+			if reason, ok := condMap["reason"].(string); ok && reason != "" {
+				return reason
+			}
+			if status, ok := condMap["status"].(string); ok && status != "" {
+				return status
+			}
+		}
+	}
+	if len(conditions) > 0 {
+		if condMap, ok := conditions[0].(map[string]interface{}); ok {
+			if reason, ok := condMap["reason"].(string); ok && reason != "" {
+				return reason
+			}
+			if status, ok := condMap["status"].(string); ok && status != "" {
+				return status
+			}
+		}
+	}
+	return "N/A"
 }
 
 func (recorder *Recorder) GetOrCreateReconciledResults() *RecorderReconciledResults {

--- a/pkg/cli/preview/result.go
+++ b/pkg/cli/preview/result.go
@@ -51,6 +51,7 @@ func (s ReconcileStatus) String() string {
 // GKNNReconciledResult is the result of reconciling a GKNN object with a specific controller type.
 type GKNNReconciledResult struct {
 	GKNN            GKNN
+	CurrentStatus   string
 	ControllerType  k8s.ReconcilerType
 	ReconcileStatus ReconcileStatus
 	Diffs           *structuredreporting.Diff
@@ -59,7 +60,7 @@ type GKNNReconciledResult struct {
 
 // FormatGKNNReconciledResult formats the GKNNReconciledResult into a string.
 func (r *GKNNReconciledResult) FormatGKNNReconciledResult() string {
-	return fmt.Sprintf("ns=\"%s\" name=\"%s\" group=\"%s\" kind=\"%s\" controller_type=\"%s\" diffs=\"%s\" reconcile_status=\"%s\"", r.GKNN.Namespace, r.GKNN.Name, r.GKNN.Group, r.GKNN.Kind, r.ControllerType, FormatFieldIDs(r.Diffs), r.ReconcileStatus.String())
+	return fmt.Sprintf("ns=\"%s\" name=\"%s\" group=\"%s\" kind=\"%s\" current_status=\"%s\" controller_type=\"%s\" diffs=\"%s\" reconcile_status=\"%s\"", r.GKNN.Namespace, r.GKNN.Name, r.GKNN.Group, r.GKNN.Kind, r.CurrentStatus, r.ControllerType, FormatFieldIDs(r.Diffs), r.ReconcileStatus.String())
 }
 
 func FormatFieldIDs(diffs *structuredreporting.Diff) string {
@@ -92,9 +93,14 @@ func (r *Recorder) GenerateRecorderReconciledResults() *RecorderReconciledResult
 		results: make(map[GKNN]*GKNNReconciledResult),
 	}
 
-	for gknn := range r.objects {
+	for gknn, objInfo := range r.objects {
+		currentStatus := objInfo.currentStatus
+		if currentStatus == "" {
+			currentStatus = "N/A"
+		}
 		result := &GKNNReconciledResult{
 			GKNN:            gknn,
+			CurrentStatus:   currentStatus,
 			Diffs:           &structuredreporting.Diff{},
 			ReconcileStatus: ReconcileStatusHealthy,
 			GCPActions:      []*gcpAction{},
@@ -145,11 +151,12 @@ func (r *RecorderReconciledResults) CombinedSummaryReport(summaryFile string, al
 		fmt.Fprintf(f, "Detected %d good and %d bad objects in alternative run\n", altResult.goodCount, altResult.badCount)
 	}
 	w := tabwriter.NewWriter(f, 0, 0, 3, ' ', 0)
-	fmt.Fprintln(w, "GROUP\tKIND\tNAME\tDEFAULT-CONTROLLER\tDEFAULT-RESULT\tDEFAULT-DIFFS\tALTERNATIVE-CONTROLLER\tALTERNATIVE-RESULT\tALTERNATIVE-DIFFS")
+	fmt.Fprintln(w, "GROUP\tKIND\tNAMESPACE\tNAME\tCURRENT-STATUS\tDEFAULT-CONTROLLER\tDEFAULT-RESULT\tALTERNATIVE-CONTROLLER\tALTERNATIVE-RESULT\tDEFAULT-DIFFS\tALTERNATIVE-DIFFS")
 	type resultPair struct {
-		def  *GKNNReconciledResult
-		alt  *GKNNReconciledResult
-		gknn GKNN
+		def           *GKNNReconciledResult
+		alt           *GKNNReconciledResult
+		gknn          GKNN
+		currentStatus string
 	}
 
 	type combinedResult struct {
@@ -163,8 +170,11 @@ func (r *RecorderReconciledResults) CombinedSummaryReport(summaryFile string, al
 	addPair := func(gknn GKNN, result *GKNNReconciledResult, isAlt bool) {
 		pair, ok := combined.results[gknn]
 		if !ok {
-			pair = &resultPair{gknn: gknn}
+			pair = &resultPair{gknn: gknn, currentStatus: "N/A"}
 			combined.results[gknn] = pair
+		}
+		if result != nil && result.CurrentStatus != "" && result.CurrentStatus != "N/A" {
+			pair.currentStatus = result.CurrentStatus
 		}
 		if isAlt {
 			pair.alt = result
@@ -249,7 +259,11 @@ func (r *RecorderReconciledResults) CombinedSummaryReport(summaryFile string, al
 			altStatus = "Missing"
 		}
 
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", pair.gknn.Group, pair.gknn.Kind, pair.gknn.Name, defCtrl, defStatus, defDiffs, altCtrl, altStatus, altDiffs)
+		currStatus := pair.currentStatus
+		if currStatus == "" {
+			currStatus = "N/A"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", pair.gknn.Group, pair.gknn.Kind, pair.gknn.Namespace, pair.gknn.Name, currStatus, defCtrl, defStatus, altCtrl, altStatus, defDiffs, altDiffs)
 	}
 
 	if err := w.Flush(); err != nil {

--- a/pkg/cli/preview/result_test.go
+++ b/pkg/cli/preview/result_test.go
@@ -108,11 +108,13 @@ func TestCombinedSummaryReport(t *testing.T) {
 		results: map[GKNN]*GKNNReconciledResult{
 			{Group: "g1", Kind: "K1", Namespace: "n1", Name: "name1"}: {
 				GKNN:            GKNN{Group: "g1", Kind: "K1", Namespace: "n1", Name: "name1"},
+				CurrentStatus:   "UpToDate",
 				ControllerType:  k8s.ReconcilerType("tf"),
 				ReconcileStatus: ReconcileStatusHealthy,
 			},
 			{Group: "g3", Kind: "K3", Namespace: "n3", Name: "name3"}: {
 				GKNN:            GKNN{Group: "g3", Kind: "K3", Namespace: "n3", Name: "name3"},
+				CurrentStatus:   "UpdateFailed",
 				ControllerType:  k8s.ReconcilerType("tf"),
 				ReconcileStatus: ReconcileStatusUnhealthy,
 			},
@@ -122,16 +124,19 @@ func TestCombinedSummaryReport(t *testing.T) {
 		results: map[GKNN]*GKNNReconciledResult{
 			{Group: "g1", Kind: "K1", Namespace: "n1", Name: "name1"}: {
 				GKNN:            GKNN{Group: "g1", Kind: "K1", Namespace: "n1", Name: "name1"},
+				CurrentStatus:   "UpToDate",
 				ControllerType:  k8s.ReconcilerType("direct"),
 				ReconcileStatus: ReconcileStatusUnhealthy,
 			},
 			{Group: "g2", Kind: "K2", Namespace: "n2", Name: "name2"}: {
 				GKNN:            GKNN{Group: "g2", Kind: "K2", Namespace: "n2", Name: "name2"},
+				CurrentStatus:   "UpToDate",
 				ControllerType:  k8s.ReconcilerType("direct"),
 				ReconcileStatus: ReconcileStatusHealthy,
 			},
 			{Group: "g3", Kind: "K3", Namespace: "n3", Name: "name3"}: {
 				GKNN:            GKNN{Group: "g3", Kind: "K3", Namespace: "n3", Name: "name3"},
+				CurrentStatus:   "UpdateFailed",
 				ControllerType:  k8s.ReconcilerType("direct"),
 				ReconcileStatus: ReconcileStatusUnhealthy,
 			},
@@ -163,10 +168,10 @@ func TestCombinedSummaryReport(t *testing.T) {
 
 	// Verify the content contains the expected headers and rows
 	expectedRows := []string{
-		"GROUP   KIND   NAME    DEFAULT-CONTROLLER   DEFAULT-RESULT   DEFAULT-DIFFS   ALTERNATIVE-CONTROLLER   ALTERNATIVE-RESULT   ALTERNATIVE-DIFFS",
-		"g1      K1     name1   tf                   HEALTHY          N/A             direct                   UNHEALTHY            N/A",
-		"g2      K2     name2   N/A                  N/A              N/A             direct                   HEALTHY              N/A",
-		"g3      K3     name3   tf                   UNHEALTHY        N/A             direct                   UNHEALTHY            N/A",
+		"GROUP   KIND   NAMESPACE   NAME    CURRENT-STATUS   DEFAULT-CONTROLLER   DEFAULT-RESULT   ALTERNATIVE-CONTROLLER   ALTERNATIVE-RESULT   DEFAULT-DIFFS   ALTERNATIVE-DIFFS",
+		"g1      K1     n1          name1   UpToDate         tf                   HEALTHY          direct                   UNHEALTHY            N/A             N/A",
+		"g2      K2     n2          name2   UpToDate         N/A                  N/A              direct                   HEALTHY              N/A             N/A",
+		"g3      K3     n3          name3   UpdateFailed     tf                   UNHEALTHY        direct                   UNHEALTHY            N/A             N/A",
 	}
 
 	for _, row := range expectedRows {


### PR DESCRIPTION
## Description
This PR enhances the `config-connector preview` summary report by:
1. Adding the missing `NAMESPACE` column.
2. Capturing and populating the `CURRENT-STATUS` of each resource in the cluster (e.g., `UpToDate`, `UpdateFailed`, `DependencyNotFound`).
3. Reordering columns to place `CURRENT-STATUS` right after `GROUP`, `KIND`, `NAMESPACE`, `NAME`, and moving the diff reporting columns (`DEFAULT-DIFFS`, `ALTERNATIVE-DIFFS`) to the end.

### Preview Summary Report Sample:
```text
Detected 8 good and 2 bad objects in default run
Detected 8 good and 2 bad objects in alternative run
GROUP                            KIND              NAMESPACE        NAME                                       CURRENT-STATUS       DEFAULT-CONTROLLER   DEFAULT-RESULT   ALTERNATIVE-CONTROLLER   ALTERNATIVE-RESULT   DEFAULT-DIFFS                                                                                                                                                                                              ALTERNATIVE-DIFFS
alloydb.cnrm.cloud.google.com    AlloyDBInstance   config-control   alloydb-instance-ut-use5-663-fcp-0001-rp   DependencyNotFound   direct               HEALTHY          N/A                      N/A                                                                                                                                                                                                                             N/A
bigquery.cnrm.cloud.google.com   BigQueryDataset   config-control   pubsubsubscriptiondepbigquerycanary        UpToDate             tf                   HEALTHY          direct                   HEALTHY                                                                                                                                                                                                                         
bigquery.cnrm.cloud.google.com   BigQueryTable     config-control   bigquerycanary-timepartition               UpToDate             tf                   UNHEALTHY        direct                   UNHEALTHY            time_partitioning.0.require_partition_filter                                                                                                                                                               require_partition_filter
bigquery.cnrm.cloud.google.com   BigQueryTable     config-control   pubsubsubscriptiondepbigquerycanary        UpToDate             tf                   HEALTHY          direct                   HEALTHY                                                                                                                                                                                                                         
spanner.cnrm.cloud.google.com    SpannerInstance   config-control   spannerinstance-sample                     UpToDate             direct               HEALTHY          direct                   HEALTHY                                                                                                                                                                                                                         
spanner.cnrm.cloud.google.com    SpannerInstance   config-control   spannerinstance-test-verbosity             UpToDate             direct               HEALTHY          direct                   HEALTHY                                                                                                                                                                                                                         
sql.cnrm.cloud.google.com        SQLInstance       config-control   sqlinstanceedition                         UpToDate             direct               HEALTHY          N/A                      N/A                                                                                                                                                                                                                             N/A
sql.cnrm.cloud.google.com        SQLInstance       test-autopilot   sqlinstance-test-autopilot                 UpToDate             direct               HEALTHY          N/A                      N/A                                                                                                                                                                                                                             N/A
storage.cnrm.cloud.google.com    StorageBucket     config-control   kcc-generated-bucket-228                   UpdateFailed         tf                   UNHEALTHY        N/A                      N/A                  force_destroy,labels.label-one,labels.managed-by-cnrm,location,name,project,public_access_prevention,self_link,soft_delete_policy.#,storage_class,uniform_bucket_level_access,url,versioning.#,website.#   N/A
storage.cnrm.cloud.google.com    StorageBucket     config-control   prod-canary-cc-autopilot-sample            UpToDate             tf                   HEALTHY          N/A                      N/A                                                                                                                                                                                                                             N/A
```

## Release Notes
```release-note
Added `NAMESPACE` and `CURRENT-STATUS` columns to the preview summary report.
```