### PR TITLE
operator: automatically roll controller manager pods on ResourceSettings changes

### DIFF
--- a/docs/features/controlled-cr-reconciliation.md
+++ b/docs/features/controlled-cr-reconciliation.md
@@ -19,6 +19,14 @@ Because both global and local settings use the same mode, they combine **additiv
 * **In Exclusive Mode**: A resource is excluded (ignored) if it is listed in the `ConfigConnector` **OR** the `ConfigConnectorContext`.
 * **In Inclusive Mode**: A resource is included (reconciled) if it is listed in the `ConfigConnector` **OR** the `ConfigConnectorContext`.
 
+### Applying Changes (Automatic Pod Rollout)
+
+Selective controller registration and watch stream management occurs when the controller manager pod initializes. To apply changes without manual intervention:
+
+* The **Config Connector Operator** automatically calculates a deterministic hash of the active `resourceSettings` and injects it as a pod template annotation (`cnrm.cloud.google.com/resource-settings-hash`) on the `cnrm-controller-manager` StatefulSet.
+* When `resourceSettings` is created, modified, or removed in `ConfigConnector` or `ConfigConnectorContext`, the operator updates the StatefulSet template annotation, and Kubernetes automatically initiates a **rolling restart** of the target controller manager pod(s).
+* Upon startup, the controller manager registers and opens watch streams exclusively for the enabled resources.
+
 ## Configuration Options
 
 To configure this feature, manipulate the `ResourceSettings` block in your `ConfigConnector` and `ConfigConnectorContext` definitions.

--- a/operator/pkg/controllers/configconnector/experiments.go
+++ b/operator/pkg/controllers/configconnector/experiments.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/manifest"
 
 	corev1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/apis/core/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/controllers"
 )
 
 func (r *Reconciler) transformForExperiments() declarative.ObjectTransform {
@@ -42,6 +43,19 @@ func (r *Reconciler) transformForExperiments() declarative.ObjectTransform {
 }
 
 func (r *Reconciler) applyExperiments(ctx context.Context, cc *corev1beta1.ConfigConnector, m *manifest.Objects) error {
+	var ccSettings *corev1beta1.ResourceSettings
+	if cc.Spec.Experiments != nil {
+		ccSettings = cc.Spec.Experiments.ResourceSettings
+	}
+	for _, item := range m.Items {
+		if IsControllerManagerStatefulSet(item) {
+			u := item.UnstructuredObject()
+			if err := controllers.ApplyResourceSettingsHashToPodTemplate(u, ccSettings, nil); err != nil {
+				return err
+			}
+		}
+	}
+
 	if cc.Spec.Experiments == nil {
 		return nil
 	}

--- a/operator/pkg/controllers/configconnector/experiments_test.go
+++ b/operator/pkg/controllers/configconnector/experiments_test.go
@@ -21,6 +21,7 @@ import (
 	corev1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/apis/core/v1beta1"
 	testcontroller "github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/test/controller"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/manifest"
 )
 
@@ -158,5 +159,48 @@ func TestApplyMultiClusterLeaderElection(t *testing.T) {
 				t.Fatalf("StatefulSet not found in manifest")
 			}
 		})
+	}
+}
+
+func TestApplyResourceSettingsHashInClusterMode(t *testing.T) {
+	ctx := context.Background()
+
+	getManifests := func(t *testing.T) *manifest.Objects {
+		return testcontroller.ParseObjects(ctx, t, testcontroller.ClusterModeComponents)
+	}
+
+	m := getManifests(t)
+	r := &Reconciler{}
+
+	cc := &corev1beta1.ConfigConnector{
+		Spec: corev1beta1.ConfigConnectorSpec{
+			Experiments: &corev1beta1.CCExperiments{
+				ResourceSettings: &corev1beta1.ResourceSettings{
+					Mode: corev1beta1.ResourceSettingsModeExclude,
+					Resources: []corev1beta1.ResourceFilter{
+						{Group: ptr.To("storage.cnrm.cloud.google.com")},
+					},
+				},
+			},
+		},
+	}
+
+	if err := r.applyExperiments(ctx, cc, m); err != nil {
+		t.Fatalf("applyExperiments failed: %v", err)
+	}
+
+	foundStatefulSet := false
+	for _, item := range m.Items {
+		if IsControllerManagerStatefulSet(item) {
+			foundStatefulSet = true
+			templateAnnotations, _, _ := unstructured.NestedStringMap(item.UnstructuredObject().Object, "spec", "template", "metadata", "annotations")
+			hash := templateAnnotations["cnrm.cloud.google.com/resource-settings-hash"]
+			if hash == "" {
+				t.Errorf("expected cnrm.cloud.google.com/resource-settings-hash annotation on StatefulSet pod template, but was empty")
+			}
+		}
+	}
+	if !foundStatefulSet {
+		t.Fatalf("StatefulSet not found in manifest")
 	}
 }

--- a/operator/pkg/controllers/configconnectorcontext/configconnectorcontext_controller.go
+++ b/operator/pkg/controllers/configconnectorcontext/configconnectorcontext_controller.go
@@ -91,6 +91,25 @@ func Add(mgr ctrl.Manager, opt *ReconcilerOptions) error {
 		Named(controllerName).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 20}).
 		WatchesRawSource(source.TypedChannel(r.customizationWatcher.Events(), &handler.EnqueueRequestForObject{})).
+		Watches(
+			&corev1beta1.ConfigConnector{},
+			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, _ client.Object) []reconcile.Request {
+				cccList := &corev1beta1.ConfigConnectorContextList{}
+				if err := r.client.List(ctx, cccList); err != nil {
+					return nil
+				}
+				var reqs []reconcile.Request
+				for _, ccc := range cccList.Items {
+					reqs = append(reqs, reconcile.Request{
+						NamespacedName: types.NamespacedName{
+							Namespace: ccc.Namespace,
+							Name:      ccc.Name,
+						},
+					})
+				}
+				return reqs
+			}),
+		).
 		For(obj, builder.OnlyMetadata).
 		Build(r)
 	if err != nil {

--- a/operator/pkg/controllers/configconnectorcontext/namespaced.go
+++ b/operator/pkg/controllers/configconnectorcontext/namespaced.go
@@ -237,7 +237,7 @@ func handleControllerManagerStatefulSet(ctx context.Context, c client.Client, cc
 		return nil, fmt.Errorf("error deleting stale StatefulSet for watched namespace %v: %w", ccc.Namespace, err)
 	}
 
-	if err := applyConfigConnectorExperiments(ctx, c, u); err != nil {
+	if err := applyConfigConnectorExperiments(ctx, c, ccc, u); err != nil {
 		return nil, err
 	}
 
@@ -253,27 +253,40 @@ func handleControllerManagerStatefulSetPerNamespace(ctx context.Context, c clien
 		return nil, fmt.Errorf("error deleting stale StatefulSet for watched namespace %v: %w", ccc.Namespace, err)
 	}
 
-	if err := applyConfigConnectorExperiments(ctx, c, u); err != nil {
+	if err := applyConfigConnectorExperiments(ctx, c, ccc, u); err != nil {
 		return nil, err
 	}
 
 	return manifest.NewObject(u)
 }
 
-func applyConfigConnectorExperiments(ctx context.Context, c client.Client, u *unstructured.Unstructured) error {
+func applyConfigConnectorExperiments(ctx context.Context, c client.Client, ccc *corev1beta1.ConfigConnectorContext, u *unstructured.Unstructured) error {
 	cc, err := controllers.GetConfigConnector(ctx, c, controllers.ValidConfigConnectorNamespacedName)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("error getting the ConfigConnector object %v: %w", controllers.ValidConfigConnectorNamespacedName, err)
 		}
-		// If CC is not found (e.g. during deletion tests), just skip applying experiments.
-		return nil
+		// If CC is not found (e.g. during deletion tests), apply with nil CC.
+		return applyExperimentsToManagerContainer(u, nil, ccc)
 	}
-	return applyExperimentsToManagerContainer(u, cc)
+	return applyExperimentsToManagerContainer(u, cc, ccc)
 }
 
-func applyExperimentsToManagerContainer(u *unstructured.Unstructured, cc *corev1beta1.ConfigConnector) error {
-	if cc.Spec.Experiments == nil {
+func applyExperimentsToManagerContainer(u *unstructured.Unstructured, cc *corev1beta1.ConfigConnector, ccc *corev1beta1.ConfigConnectorContext) error {
+	var ccSettings *corev1beta1.ResourceSettings
+	if cc != nil && cc.Spec.Experiments != nil {
+		ccSettings = cc.Spec.Experiments.ResourceSettings
+	}
+	var cccSettings *corev1beta1.ResourceSettings
+	if ccc != nil && ccc.Spec.Experiments != nil {
+		cccSettings = ccc.Spec.Experiments.ResourceSettings
+	}
+
+	if err := controllers.ApplyResourceSettingsHashToPodTemplate(u, ccSettings, cccSettings); err != nil {
+		return err
+	}
+
+	if cc == nil || cc.Spec.Experiments == nil {
 		return nil
 	}
 

--- a/operator/pkg/controllers/configconnectorcontext/resourcesettings_test.go
+++ b/operator/pkg/controllers/configconnectorcontext/resourcesettings_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configconnectorcontext
+
+import (
+	"testing"
+
+	corev1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/apis/core/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/controllers"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/ptr"
+)
+
+func TestApplyResourceSettingsHashInNamespacedMode(t *testing.T) {
+	u := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "StatefulSet",
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"annotations": map[string]interface{}{},
+					},
+				},
+			},
+		},
+	}
+
+	cc := &corev1beta1.ConfigConnector{
+		Spec: corev1beta1.ConfigConnectorSpec{
+			Experiments: &corev1beta1.CCExperiments{
+				ResourceSettings: &corev1beta1.ResourceSettings{
+					Mode: corev1beta1.ResourceSettingsModeExclude,
+					Resources: []corev1beta1.ResourceFilter{
+						{Group: ptr.To("pubsub.cnrm.cloud.google.com")},
+					},
+				},
+			},
+		},
+	}
+
+	ccc := &corev1beta1.ConfigConnectorContext{
+		Spec: corev1beta1.ConfigConnectorContextSpec{
+			Experiments: &corev1beta1.Experiments{
+				ResourceSettings: &corev1beta1.ResourceSettings{
+					Mode: corev1beta1.ResourceSettingsModeExclude,
+					Resources: []corev1beta1.ResourceFilter{
+						{Group: ptr.To("storage.cnrm.cloud.google.com"), Kind: ptr.To("StorageBucket")},
+					},
+				},
+			},
+		},
+	}
+
+	if err := applyExperimentsToManagerContainer(u, cc, ccc); err != nil {
+		t.Fatalf("applyExperimentsToManagerContainer failed: %v", err)
+	}
+
+	templateAnnotations, _, err := unstructured.NestedStringMap(u.Object, "spec", "template", "metadata", "annotations")
+	if err != nil {
+		t.Fatalf("failed to get pod template annotations: %v", err)
+	}
+
+	hash := templateAnnotations[controllers.ResourceSettingsHashAnnotation]
+	if hash == "" {
+		t.Fatalf("expected %s annotation to be set, but was empty", controllers.ResourceSettingsHashAnnotation)
+	}
+
+	// Change CCC settings and verify hash changes
+	ccc.Spec.Experiments.ResourceSettings.Resources = append(ccc.Spec.Experiments.ResourceSettings.Resources, corev1beta1.ResourceFilter{
+		Group: ptr.To("compute.cnrm.cloud.google.com"),
+	})
+
+	if err := applyExperimentsToManagerContainer(u, cc, ccc); err != nil {
+		t.Fatalf("applyExperimentsToManagerContainer with updated CCC failed: %v", err)
+	}
+
+	templateAnnotations, _, _ = unstructured.NestedStringMap(u.Object, "spec", "template", "metadata", "annotations")
+	newHash := templateAnnotations[controllers.ResourceSettingsHashAnnotation]
+	if newHash == "" || newHash == hash {
+		t.Fatalf("expected different hash after updating CCC, got %q vs %q", newHash, hash)
+	}
+}

--- a/operator/pkg/controllers/resourcesettings.go
+++ b/operator/pkg/controllers/resourcesettings.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	corev1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/apis/core/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	ResourceSettingsHashAnnotation = "cnrm.cloud.google.com/resource-settings-hash"
+)
+
+// ComputeResourceSettingsHash calculates a deterministic SHA-256 hash for the given resourceSettings.
+// Returns an empty string if both ccSettings and cccSettings are nil or empty.
+func ComputeResourceSettingsHash(ccSettings *corev1beta1.ResourceSettings, cccSettings *corev1beta1.ResourceSettings) (string, error) {
+	if (ccSettings == nil || (len(ccSettings.Resources) == 0 && ccSettings.Mode == "")) &&
+		(cccSettings == nil || (len(cccSettings.Resources) == 0 && cccSettings.Mode == "")) {
+		return "", nil
+	}
+
+	payload := struct {
+		CC  *corev1beta1.ResourceSettings `json:"cc,omitempty"`
+		CCC *corev1beta1.ResourceSettings `json:"ccc,omitempty"`
+	}{
+		CC:  ccSettings,
+		CCC: cccSettings,
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("error marshalling resourceSettings for hash computation: %w", err)
+	}
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:]), nil
+}
+
+// ApplyResourceSettingsHashToPodTemplate sets or deletes the resourceSettings hash annotation
+// on the Pod template of a StatefulSet unstructured object.
+func ApplyResourceSettingsHashToPodTemplate(u *unstructured.Unstructured, ccSettings *corev1beta1.ResourceSettings, cccSettings *corev1beta1.ResourceSettings) error {
+	hash, err := ComputeResourceSettingsHash(ccSettings, cccSettings)
+	if err != nil {
+		return err
+	}
+
+	annotations, _, err := unstructured.NestedStringMap(u.Object, "spec", "template", "metadata", "annotations")
+	if err != nil {
+		return fmt.Errorf("failed to get pod template annotations: %w", err)
+	}
+
+	if hash != "" {
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[ResourceSettingsHashAnnotation] = hash
+	} else if annotations != nil {
+		delete(annotations, ResourceSettingsHashAnnotation)
+	}
+
+	if annotations != nil {
+		if err := unstructured.SetNestedStringMap(u.Object, annotations, "spec", "template", "metadata", "annotations"); err != nil {
+			return fmt.Errorf("failed to set pod template annotations: %w", err)
+		}
+	}
+	return nil
+}

--- a/operator/pkg/controllers/resourcesettings_test.go
+++ b/operator/pkg/controllers/resourcesettings_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"testing"
+
+	corev1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/apis/core/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/ptr"
+)
+
+func TestComputeResourceSettingsHash(t *testing.T) {
+	// Both nil
+	hash, err := ComputeResourceSettingsHash(nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hash != "" {
+		t.Errorf("expected empty hash for nil settings, got %q", hash)
+	}
+
+	// CC settings only
+	ccSettings := &corev1beta1.ResourceSettings{
+		Mode: corev1beta1.ResourceSettingsModeExclude,
+		Resources: []corev1beta1.ResourceFilter{
+			{Group: ptr.To("pubsub.cnrm.cloud.google.com")},
+		},
+	}
+	hash1, err := ComputeResourceSettingsHash(ccSettings, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hash1 == "" {
+		t.Errorf("expected non-empty hash, got empty")
+	}
+
+	// CCC settings only
+	cccSettings := &corev1beta1.ResourceSettings{
+		Mode: corev1beta1.ResourceSettingsModeExclude,
+		Resources: []corev1beta1.ResourceFilter{
+			{Group: ptr.To("storage.cnrm.cloud.google.com"), Kind: ptr.To("StorageBucket")},
+		},
+	}
+	hash2, err := ComputeResourceSettingsHash(nil, cccSettings)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hash2 == "" || hash2 == hash1 {
+		t.Errorf("expected distinct non-empty hash, got %q", hash2)
+	}
+
+	// Both CC and CCC settings
+	hash3, err := ComputeResourceSettingsHash(ccSettings, cccSettings)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hash3 == "" || hash3 == hash1 || hash3 == hash2 {
+		t.Errorf("expected distinct non-empty combined hash, got %q", hash3)
+	}
+
+	// Determinism
+	hash3Again, err := ComputeResourceSettingsHash(ccSettings, cccSettings)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hash3 != hash3Again {
+		t.Errorf("expected deterministic hash, got %q vs %q", hash3, hash3Again)
+	}
+}
+
+func TestApplyResourceSettingsHashToPodTemplate(t *testing.T) {
+	u := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "StatefulSet",
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"annotations": map[string]interface{}{
+							"existing-annotation": "true",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ccSettings := &corev1beta1.ResourceSettings{
+		Mode: corev1beta1.ResourceSettingsModeInclude,
+		Resources: []corev1beta1.ResourceFilter{
+			{Group: ptr.To("iam.cnrm.cloud.google.com"), Kind: ptr.To("IAMServiceAccount")},
+		},
+	}
+
+	if err := ApplyResourceSettingsHashToPodTemplate(u, ccSettings, nil); err != nil {
+		t.Fatalf("unexpected error applying hash: %v", err)
+	}
+
+	annotations, _, err := unstructured.NestedStringMap(u.Object, "spec", "template", "metadata", "annotations")
+	if err != nil {
+		t.Fatalf("unexpected error getting annotations: %v", err)
+	}
+	if annotations["existing-annotation"] != "true" {
+		t.Errorf("expected existing annotation preserved")
+	}
+	if annotations[ResourceSettingsHashAnnotation] == "" {
+		t.Errorf("expected %s annotation to be set", ResourceSettingsHashAnnotation)
+	}
+
+	// Setting to nil removes annotation
+	if err := ApplyResourceSettingsHashToPodTemplate(u, nil, nil); err != nil {
+		t.Fatalf("unexpected error removing hash: %v", err)
+	}
+	annotations, _, _ = unstructured.NestedStringMap(u.Object, "spec", "template", "metadata", "annotations")
+	if _, exists := annotations[ResourceSettingsHashAnnotation]; exists {
+		t.Errorf("expected %s annotation to be removed when settings are nil", ResourceSettingsHashAnnotation)
+	}
+}


### PR DESCRIPTION
### Summary
This PR enables automatic rolling restart of `cnrm-controller-manager` StatefulSet pods whenever `spec.experiments.resourceSettings` is configured, updated, or removed in `ConfigConnector` (cluster mode) or `ConfigConnectorContext` (namespaced mode).

### Changes
1. **Hash Helper (`operator/pkg/controllers/resourcesettings.go`)**: Computes a deterministic SHA-256 hash of active `ResourceSettings` across CC and CCC, and injects/removes the pod template annotation `cnrm.cloud.google.com/resource-settings-hash`.
2. **Cluster Mode (`operator/pkg/controllers/configconnector/experiments.go`)**: Injects the hash into the cluster-wide `cnrm-controller-manager` StatefulSet pod template.
3. **Namespaced Mode (`operator/pkg/controllers/configconnectorcontext/namespaced.go`)**: Injects the combined CC+CCC hash into per-namespace `cnrm-controller-manager-${NAMESPACE}` StatefulSet pod templates.
4. **CCC Controller Watch (`operator/pkg/controllers/configconnectorcontext/configconnectorcontext_controller.go`)**: Adds a watch for `ConfigConnector` so that global `ResourceSettings` changes automatically trigger reconciliation and rollout across all namespace managers.
5. **Unit Tests**: Added test coverage in `resourcesettings_test.go` and controller test suites.
6. **Documentation**: Updated `docs/features/controlled-cr-reconciliation.md` to describe the automated pod rollout mechanism.