### PR TITLE
ci: fix review assigner labels

### DIFF
--- a/.agents/review-assigner.md
+++ b/.agents/review-assigner.md
@@ -1,6 +1,6 @@
 ---
 name: PR Review Assigner
-description: Automatically assigns ready-for-human PRs to k8s-config-connector-team members, striving to maintain assigned review counts within defined thresholds.
+description: Automatically assigns overseer/ready-for-human PRs to k8s-config-connector-team members, striving to maintain assigned review counts within defined thresholds.
 schedule: "never"
 skipPR: true
 ---
@@ -23,10 +23,10 @@ limitations under the License.
 
 # Role
 You are an automated PR review workload balancer for the `k8s-config-connector-team`.
-Your task is to scan open Pull Requests in `GoogleCloudPlatform/k8s-config-connector` and assign eligible `ready-for-human` PRs to members of `k8s-config-connector-team` to keep each member's assigned review count between 5 and 10.
+Your task is to scan open Pull Requests in `GoogleCloudPlatform/k8s-config-connector` and assign eligible `overseer/ready-for-human` PRs to members of `k8s-config-connector-team` to keep each member's assigned review count between 5 and 10.
 
 # Context & Objective
-As KCC resources move through our agentic code generation pipeline, automated agents perform initial validation and label PRs with `ready-for-human`. This chore executes every 30 minutes to balance review load across `k8s-config-connector-team` while preserving workflow context continuity.
+As KCC resources move through our agentic code generation pipeline, automated agents perform initial validation and label PRs with `overseer/ready-for-human`. This chore executes every 30 minutes to balance review load across `k8s-config-connector-team` while preserving workflow context continuity.
 
 # Team Definition
 The `k8s-config-connector-team` is composed of the following GitHub handles:
@@ -46,12 +46,13 @@ The `k8s-config-connector-team` is composed of the following GitHub handles:
    - **Maximum hard ceiling**: 10 assigned open PRs per member. Never assign additional PRs to any member who already has **10 or more** open review requests.
 
 2. **Strict Eligibility Rule**:
-   - **STRICT**: Assign ONLY PRs that have the label `ready-for-human`. Do NOT assign any PR lacking this label under any circumstances.
-   - **EXEMPTION**: If the total pool of unassigned `ready-for-human` PRs is insufficient to bring all team members up to 5 assigned PRs, team members are exempted from having 5 assigned PRs.
+   - **STRICT**: Assign ONLY PRs that have the label `overseer/ready-for-human`. Do NOT assign any PR lacking this label under any circumstances.
+   - **STOP LABEL**: Do NOT assign any PR that has the label `overseer/stop`.
+   - **EXEMPTION**: If the total pool of unassigned `overseer/ready-for-human` PRs is insufficient to bring all team members up to 5 assigned PRs, team members are exempted from having 5 assigned PRs.
 
 3. **Workflow Affinity Preference (Soft Rule)**:
    - Multi-level workflow pipelines (such as root tracking issue #10976 and sub-issue #10276) generate multiple sub-issues and PRs (e.g. PR #10992 referencing both #10276 and #10976).
-   - If an unassigned `ready-for-human` PR references any issue ID (root tracking issue or sub-issue) that a team member is already reviewing (and that member has `< 10` assigned PRs), **prefer assigning the new PR to that same team member** to maintain context continuity.
+   - If an unassigned `overseer/ready-for-human` PR references any issue ID (root tracking issue or sub-issue) that a team member is already reviewing (and that member has `< 10` assigned PRs), **prefer assigning the new PR to that same team member** to maintain context continuity.
 
 ---
 

--- a/dev/tasks/balance_reviews.py
+++ b/dev/tasks/balance_reviews.py
@@ -54,7 +54,7 @@ def audit_workloads(prs, team):
     Returns:
         workloads: dict of team member -> open review count.
         tracking_issue_to_reviewer: dict of issue_id -> set of team member usernames currently reviewing it.
-        unassigned_candidates: list of PRs that are candidate ready-for-human PRs.
+        unassigned_candidates: list of PRs that are candidate overseer/ready-for-human PRs.
     """
     workloads = {member: 0 for member in team}
     tracking_issue_to_reviewer = {}
@@ -78,13 +78,13 @@ def audit_workloads(prs, team):
                 for reviewer in assigned_team_reviewers:
                     tracking_issue_to_reviewer[issue_id].add(reviewer)
         else:
-            if "ready-for-human" in labels:
+            if "overseer/ready-for-human" in labels and "overseer/stop" not in labels:
                 unassigned_candidates.append(pr)
 
     return workloads, tracking_issue_to_reviewer, unassigned_candidates
 
 def balance_reviews(unassigned_candidates, team, workloads, tracking_issue_to_reviewer):
-    """Perform the review assignment algorithm on unassigned ready-for-human candidates."""
+    """Perform the review assignment algorithm on unassigned overseer/ready-for-human candidates."""
     assignments = []
     
     # Sort candidates by number to ensure deterministic ordering
@@ -172,7 +172,7 @@ def main():
     for member in TEAM:
         print(f"  {member}: {workloads[member]} assigned reviews")
 
-    print(f"\nFound {len(candidates)} unassigned ready-for-human PRs.")
+    print(f"\nFound {len(candidates)} unassigned overseer/ready-for-human PRs.")
 
     assignments = balance_reviews(candidates, TEAM, workloads, tracking_maps)
 

--- a/dev/tasks/balance_reviews_test.py
+++ b/dev/tasks/balance_reviews_test.py
@@ -51,14 +51,14 @@ class TestBalanceReviews(unittest.TestCase):
                 "title": "Candidate 1",
                 "body": "Fixes #100",
                 "requested_reviewers": [{"login": "outsider"}],
-                "labels": [{"name": "ready-for-human"}]
+                "labels": [{"name": "overseer/ready-for-human"}]
             },
             {
                 "number": 4,
                 "title": "Candidate 2",
                 "body": "No tracking issue",
                 "requested_reviewers": [],
-                "labels": [{"name": "ready-for-human"}]
+                "labels": [{"name": "overseer/ready-for-human"}]
             },
             {
                 "number": 5,
@@ -66,6 +66,13 @@ class TestBalanceReviews(unittest.TestCase):
                 "body": "",
                 "requested_reviewers": [],
                 "labels": []
+            },
+            {
+                "number": 6,
+                "title": "Stopped PR",
+                "body": "Fixes #100",
+                "requested_reviewers": [],
+                "labels": [{"name": "overseer/ready-for-human"}, {"name": "overseer/stop"}]
             }
         ]
         
@@ -77,7 +84,7 @@ class TestBalanceReviews(unittest.TestCase):
         # Check tracking issue maps
         self.assertEqual(tracking_map, {100: {"alice"}, 200: {"bob"}})
         
-        # Check candidate extraction (only #3 and #4 should be candidates)
+        # Check candidate extraction (only #3 and #4 should be candidates, #6 has overseer/stop)
         candidate_numbers = [pr["number"] for pr in candidates]
         self.assertEqual(candidate_numbers, [3, 4])
 
@@ -94,7 +101,7 @@ class TestBalanceReviews(unittest.TestCase):
                 "title": "PR 3",
                 "body": "Fixes #100",
                 "requested_reviewers": [],
-                "labels": [{"name": "ready-for-human"}]
+                "labels": [{"name": "overseer/ready-for-human"}]
             }
         ]
         
@@ -122,7 +129,7 @@ class TestBalanceReviews(unittest.TestCase):
                 "title": "PR 3",
                 "body": "Fixes #300",
                 "requested_reviewers": [],
-                "labels": [{"name": "ready-for-human"}]
+                "labels": [{"name": "overseer/ready-for-human"}]
             }
         ]
         
@@ -146,7 +153,7 @@ class TestBalanceReviews(unittest.TestCase):
                 "title": "PR 3",
                 "body": "Fixes #300",
                 "requested_reviewers": [],
-                "labels": [{"name": "ready-for-human"}]
+                "labels": [{"name": "overseer/ready-for-human"}]
             }
         ]
         
@@ -170,7 +177,7 @@ class TestBalanceReviews(unittest.TestCase):
                 "title": "PR 3",
                 "body": "Fixes #300",
                 "requested_reviewers": [],
-                "labels": [{"name": "ready-for-human"}]
+                "labels": [{"name": "overseer/ready-for-human"}]
             }
         ]
         

--- a/docs/ai/overseer-developer-guide.md
+++ b/docs/ai/overseer-developer-guide.md
@@ -133,7 +133,7 @@ Once a PR is opened by a Coder Bot (or an existing PR is labeled with `overseer`
 - **Automated Test Failure Resolution**: If presubmit CI checks or unit tests fail, Overseer inspects the failure logs, spins up the worker sandbox, and pushes fixes.
 - **Automated Conflict Resolution**: If updates to `master` cause merge conflicts, Overseer rebases the branch and resolves standard conflicts.
 - **Automated Code Review (Selective)**: For select PRs based on configuration, `reviewbot-robot` provides initial feedback aligned with KCC review skills in `.gemini/skills/` (such as `reviewgen-greenfield-controller` and `reviewgen-brownfield-new-types`).
-- **Human Handover (`ready-for-human`)**: Once automated validations pass, the bot applies the `ready-for-human` label. The automated review assigner chore ([.agents/review-assigner.md](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/master/.agents/review-assigner.md)) periodically balances and assigns these PRs to maintainers on the `k8s-config-connector-team`.
+- **Human Handover (`overseer/ready-for-human`)**: Once automated validations pass, the bot applies the `overseer/ready-for-human` label. The automated review assigner chore ([.agents/review-assigner.md](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/master/.agents/review-assigner.md)) periodically balances and assigns these PRs to maintainers on the `k8s-config-connector-team`.
 
 ```mermaid
 sequenceDiagram


### PR DESCRIPTION
This updates the review assigner to honor the correct set of overseer labels, which is now standardized as:
- overseer/ready-for-human when the PR passes automated checks
- overseer/stop when the PR is paused

### BRIEF Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Fixes #

#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
