### PR TITLE
Fix SecretManagerSecret createTime status schema

### DIFF
--- a/apis/secretmanager/v1beta1/secretmanagersecret_types.go
+++ b/apis/secretmanager/v1beta1/secretmanagersecret_types.go
@@ -192,6 +192,9 @@ type SecretManagerSecretStatus struct {
 	   object's current state. */
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 
+	// The time at which the SecretManagerSecret was created.
+	CreateTime *string `json:"createTime,omitempty" tf:"create_time,omitempty"`
+
 	// ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource.
 	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 

--- a/apis/secretmanager/v1beta1/zz_generated.deepcopy.go
+++ b/apis/secretmanager/v1beta1/zz_generated.deepcopy.go
@@ -564,6 +564,11 @@ func (in *SecretManagerSecretStatus) DeepCopyInto(out *SecretManagerSecretStatus
 		*out = make([]v1alpha1.Condition, len(*in))
 		copy(*out, *in)
 	}
+	if in.CreateTime != nil {
+		in, out := &in.CreateTime, &out.CreateTime
+		*out = new(string)
+		**out = **in
+	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
 		*out = new(int64)

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_secretmanagersecrets.secretmanager.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_secretmanagersecrets.secretmanager.cnrm.cloud.google.com.yaml
@@ -380,6 +380,9 @@ spec:
                       type: string
                   type: object
                 type: array
+              createTime:
+                description: The time at which the SecretManagerSecret was created.
+                type: string
               externalRef:
                 description: A unique specifier for the SecretManagerSecret resource
                   in GCP.

--- a/pkg/clients/generated/apis/secretmanager/v1beta1/secretmanagersecret_types.go
+++ b/pkg/clients/generated/apis/secretmanager/v1beta1/secretmanagersecret_types.go
@@ -222,6 +222,10 @@ type SecretManagerSecretStatus struct {
 	/* Conditions represent the latest available observations of the
 	   SecretManagerSecret's current state. */
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
+	/* The time at which the SecretManagerSecret was created. */
+	// +optional
+	CreateTime *string `json:"createTime,omitempty"`
+
 	/* A unique specifier for the SecretManagerSecret resource in GCP. */
 	// +optional
 	ExternalRef *string `json:"externalRef,omitempty"`

--- a/pkg/clients/generated/apis/secretmanager/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/secretmanager/v1beta1/zz_generated.deepcopy.go
@@ -203,6 +203,11 @@ func (in *SecretManagerSecretStatus) DeepCopyInto(out *SecretManagerSecretStatus
 		*out = make([]v1alpha1.Condition, len(*in))
 		copy(*out, *in)
 	}
+	if in.CreateTime != nil {
+		in, out := &in.CreateTime, &out.CreateTime
+		*out = new(string)
+		**out = **in
+	}
 	if in.ExternalRef != nil {
 		in, out := &in.ExternalRef, &out.ExternalRef
 		*out = new(string)

--- a/tests/apichecks/observed_state_test.go
+++ b/tests/apichecks/observed_state_test.go
@@ -133,6 +133,37 @@ func TestOutputOnlyFieldsAreUnderObservedState(t *testing.T) {
 	test.CompareGoldenFile(t, "testdata/exceptions/observed_state.txt", want)
 }
 
+func TestSecretManagerSecretStatusCreateTimeSchema(t *testing.T) {
+	t.Parallel()
+
+	const (
+		group   = "secretmanager.cnrm.cloud.google.com"
+		version = "v1beta1"
+		kind    = "SecretManagerSecret"
+	)
+
+	crd, err := crdloader.GetCRD(group, version, kind)
+	if err != nil {
+		t.Fatalf("loading %s CRD: %v", kind, err)
+	}
+
+	for _, crdVersion := range crd.Spec.Versions {
+		if crdVersion.Name != version {
+			continue
+		}
+		createTime := findOpenAPIProperty(crdVersion.Schema.OpenAPIV3Schema, "status", "createTime")
+		if createTime == nil {
+			t.Fatalf("%s %s CRD does not declare status.createTime", version, kind)
+		}
+		if got, want := createTime.Type, "string"; got != want {
+			t.Fatalf("status.createTime type = %q, want %q", got, want)
+		}
+		return
+	}
+
+	t.Fatalf("%s CRD does not contain version %s", kind, version)
+}
+
 func findOpenAPIProperty(schema *apiextensionsv1.JSONSchemaProps, path ...string) *apiextensionsv1.JSONSchemaProps {
 	pos := schema
 	for _, k := range path {


### PR DESCRIPTION
### BRIEF Change description

Declare the optional `status.createTime` field for the v1beta1 `SecretManagerSecret` API, regenerate the CRD and generated clients, and add a regression test that verifies the published CRD status schema.

Fixes #12336

#### WHY do we need this change?

The Terraform provider defines `create_time` as a computed field, and the Terraform-based Config Connector path maps computed fields into resource status. However, `SecretManagerSecretStatus` did not declare the corresponding `createTime` field. As a result, the Kubernetes API server pruned the controller-reported value and emitted an unknown-field warning.

This is an additive, status-only schema change. It does not change the resource spec, reconciliation behavior, or Direct controller implementation.

#### Special notes for your reviewer:

The regression test loads the generated CRD and asserts that `status.createTime` exists with type `string`, so future field or generation regressions are detected.

#### Does this PR add something which needs to be 'release noted'?

```release-note
Fix SecretManagerSecret status schema so the controller-reported createTime field is preserved.
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

```docs
NONE
```

#### Intended Milestone

- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- `make fmt`
- `go vet ./...`
- `go test ./tests/apichecks -count=1`
- `go test ./pkg/krmtotf -run 'TestResolveSpecAndStatus' -count=1`
- `go test ./apis/secretmanager/v1beta1 ./pkg/controller/direct/secretmanager ./pkg/clients/generated/apis/secretmanager/v1beta1 -count=1`
- Targeted regression test was verified to fail before the schema change and pass after it.

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources. (Not run; this is an additive CRD status-schema change.)
