### PR TITLE
feat(controllerbuilder): generate root Spec/ObservedState from proto and infer parent from pattern

### DIFF
--- a/dev/tools/controllerbuilder/pkg/codegen/typegenerator.go
+++ b/dev/tools/controllerbuilder/pkg/codegen/typegenerator.go
@@ -41,6 +41,7 @@ type TypeGenerator struct {
 	visitedMessages         []protoreflect.MessageDescriptor
 	outputMessages          []*OutputMessageDetails
 	observedStateMessages   sets.String
+	rootMessageFullNames    sets.String
 	generatedFileAnnotation *codegenannotations.FileAnnotation
 	includeSkippedOutput    bool
 }
@@ -55,6 +56,7 @@ func NewTypeGenerator(goPackage string, outputBaseDir string, api *protoapi.Prot
 		goPackage:             goPackage,
 		api:                   api,
 		observedStateMessages: sets.NewString(),
+		rootMessageFullNames:  sets.NewString(),
 	}
 	g.generatorBase.init(outputBaseDir)
 	return g
@@ -73,6 +75,7 @@ func (g *TypeGenerator) WithIncludeSkippedOutput(includeSkippedOutput bool) *Typ
 }
 
 func (g *TypeGenerator) VisitProto(resourceProtoFullName string) error {
+	g.rootMessageFullNames.Insert(resourceProtoFullName)
 
 	descriptor, err := g.api.Files().FindDescriptorByName(protoreflect.FullName(resourceProtoFullName))
 	if err != nil {
@@ -219,6 +222,10 @@ func (g *TypeGenerator) WriteVisitedMessages() error {
 		if msg.IsMapEntry() {
 			continue
 		}
+		if g.rootMessageFullNames.Has(string(msg.FullName())) {
+			// Skip root resource messages in types.generated.go as they are generated into <kind>_types.go
+			continue
+		}
 
 		k := generatedFileKey{
 			GoPackage: g.goPackage,
@@ -281,6 +288,10 @@ func (g *TypeGenerator) WriteOutputMessages() error {
 		if msg.IsMapEntry() {
 			continue
 		}
+		if g.rootMessageFullNames.Has(string(msg.FullName())) {
+			// Skip root resource messages in types.generated.go as they are generated into <kind>_types.go
+			continue
+		}
 
 		k := generatedFileKey{
 			GoPackage: g.goPackage,
@@ -334,6 +345,117 @@ func (g *TypeGenerator) WriteOutputMessages() error {
 		WriteObservedStateMessage(&out.body, msgDetails, g.observedStateMessages)
 	}
 	return errors.Join(g.errors...)
+}
+
+func RenderParentFields(msg protoreflect.MessageDescriptor, kind string) string {
+	var sb strings.Builder
+	var res *annotations.ResourceDescriptor
+	if msg != nil && msg.Options() != nil {
+		if ext, ok := proto.GetExtension(msg.Options(), annotations.E_Resource).(*annotations.ResourceDescriptor); ok && ext != nil {
+			res = ext
+		}
+	}
+
+	hasFolder := false
+	hasProject := false
+	hasOrg := false
+	hasLocation := false
+	isSingleton := false
+
+	if res != nil && len(res.GetPattern()) > 0 {
+		pattern := res.GetPattern()[0]
+		if strings.Contains(pattern, "folders/{folder}") {
+			hasFolder = true
+		}
+		if strings.Contains(pattern, "projects/{project}") {
+			hasProject = true
+		}
+		if strings.Contains(pattern, "organizations/{organization}") {
+			hasOrg = true
+		}
+		if strings.Contains(pattern, "locations/{location}") || strings.Contains(pattern, "regions/{region}") || strings.Contains(pattern, "zones/{zone}") {
+			hasLocation = true
+		}
+		lastSegment := pattern[strings.LastIndex(pattern, "/")+1:]
+		if !strings.HasPrefix(lastSegment, "{") {
+			isSingleton = true
+		}
+	} else {
+		// Fallback default
+		hasProject = true
+		hasLocation = true
+	}
+
+	if hasFolder {
+		sb.WriteString("\t// The folder that this resource belongs to.\n")
+		sb.WriteString("\t// +optional\n")
+		sb.WriteString("\tFolderRef *refsv1beta1.FolderRef `json:\"folderRef,omitempty\"`\n\n")
+	}
+	if hasProject {
+		sb.WriteString("\t// The project that this resource belongs to.\n")
+		sb.WriteString("\t// +optional\n")
+		sb.WriteString("\tProjectRef *refsv1beta1.ProjectRef `json:\"projectRef,omitempty\"`\n\n")
+	}
+	if hasOrg {
+		sb.WriteString("\t// The organization that this resource belongs to.\n")
+		sb.WriteString("\t// +optional\n")
+		sb.WriteString("\tOrganizationRef *refsv1beta1.OrganizationRef `json:\"organizationRef,omitempty\"`\n\n")
+	}
+	if hasLocation {
+		sb.WriteString("\t// The location of this resource.\n")
+		sb.WriteString("\tLocation string `json:\"location\"`\n\n")
+	}
+	if !isSingleton {
+		sb.WriteString(fmt.Sprintf("\t// The %s name. If not given, the metadata.name will be used.\n", kind))
+		sb.WriteString("\tResourceID *string `json:\"resourceID,omitempty\"`\n")
+	}
+	return sb.String()
+}
+
+func (g *TypeGenerator) RenderSpecFields(msg protoreflect.MessageDescriptor) (string, error) {
+	if msg == nil {
+		return "", nil
+	}
+	var buf bytes.Buffer
+	fieldIndex := 0
+	for i := 0; i < msg.Fields().Len(); i++ {
+		field := msg.Fields().Get(i)
+		if field.Name() == "name" {
+			continue // Handled by Parent/ResourceID
+		}
+		if IsFieldBehavior(field, annotations.FieldBehavior_OUTPUT_ONLY) {
+			continue
+		}
+		WriteField(&buf, field, msg, fieldIndex, false)
+		fieldIndex++
+	}
+	return buf.String(), nil
+}
+
+func (g *TypeGenerator) RenderObservedStateFields(msg protoreflect.MessageDescriptor) (string, error) {
+	if msg == nil {
+		return "", nil
+	}
+	var buf bytes.Buffer
+	fieldIndex := 0
+	for i := 0; i < msg.Fields().Len(); i++ {
+		field := msg.Fields().Get(i)
+		if field.Name() == "name" {
+			continue // Handled by status.ExternalRef
+		}
+		if IsFieldBehavior(field, annotations.FieldBehavior_OUTPUT_ONLY) {
+			isMessage := field.Kind() == protoreflect.MessageKind && !field.IsMap()
+			useObservedState := false
+			if isMessage {
+				if g.observedStateMessages.Has(string(field.Message().FullName())) {
+					useObservedState = true
+				}
+			}
+			WriteField(&buf, field, msg, fieldIndex, useObservedState)
+			fieldIndex++
+		}
+	}
+	return buf.String(), nil
 }
 
 func WriteMessageAsComment(out io.Writer, msg protoreflect.MessageDescriptor, reason string) {

--- a/dev/tools/controllerbuilder/pkg/commands/generatetypes/generatetypescommand.go
+++ b/dev/tools/controllerbuilder/pkg/commands/generatetypes/generatetypescommand.go
@@ -191,7 +191,36 @@ func RunGenerateCRD(ctx context.Context, o *GenerateCRDOptions) error {
 			if scaffolder.TypeFileExists(resource) {
 				klog.V(1).Infof("file %s already exists, skipping\n", scaffolder.PathToTypeFile(resource))
 			} else {
-				err := scaffolder.AddTypeFile(resource)
+				var resourceProtoFullName string
+				if strings.Contains(resource.ProtoName, ".") {
+					resourceProtoFullName = resource.ProtoName
+				} else {
+					found := false
+					for _, svc := range strings.Split(o.ServiceName, ",") {
+						candidate := svc + "." + resource.ProtoName
+						_, err := api.Files().FindDescriptorByName(protoreflect.FullName(candidate))
+						if err == nil {
+							resourceProtoFullName = candidate
+							found = true
+							break
+						}
+					}
+					if !found {
+						resourceProtoFullName = strings.Split(o.ServiceName, ",")[0] + "." + resource.ProtoName
+					}
+				}
+
+				desc, err := api.Files().FindDescriptorByName(protoreflect.FullName(resourceProtoFullName))
+				var rootMsg protoreflect.MessageDescriptor
+				if err == nil {
+					rootMsg, _ = desc.(protoreflect.MessageDescriptor)
+				}
+
+				parentFields := codegen.RenderParentFields(rootMsg, resource.Kind)
+				specFields, _ := typeGenerator.RenderSpecFields(rootMsg)
+				observedStateFields, _ := typeGenerator.RenderObservedStateFields(rootMsg)
+
+				err = scaffolder.AddTypeFileWithFields(resource, parentFields, specFields, observedStateFields)
 				if err != nil {
 					return fmt.Errorf("add type file %s: %w", scaffolder.PathToTypeFile(resource), err)
 				}

--- a/dev/tools/controllerbuilder/pkg/commands/iteratetypes/command.go
+++ b/dev/tools/controllerbuilder/pkg/commands/iteratetypes/command.go
@@ -114,14 +114,14 @@ func writeToFile(ctx context.Context, o *Options, allproto *[]ResourceMetadata) 
 		return nil
 	}
 	f, err := os.OpenFile(o.OutputFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
-	defer f.Close()
 	if err != nil {
 		return fmt.Errorf("opening file %q: %w", o.OutputFile, err)
 	}
+	defer f.Close()
 	for _, proto := range *allproto {
 		b, err := yaml.Marshal(proto)
 		if err != nil {
-			return fmt.Errorf("marshalling proto %s: %w", proto, err)
+			return fmt.Errorf("marshalling proto %v: %w", proto, err)
 		}
 		f.WriteString(string(b) + "\n---\n")
 	}

--- a/dev/tools/controllerbuilder/pkg/commands/prunetypes/prunetypes.go
+++ b/dev/tools/controllerbuilder/pkg/commands/prunetypes/prunetypes.go
@@ -114,7 +114,8 @@ func PruneTypes(ctx context.Context, o *PruneTypesOptions) error {
 			}
 		}
 		if len(targetFiles) == 0 {
-			return fmt.Errorf("no *.generated.go files found in %s", pkgDir)
+			klog.V(1).Infof("no *.generated.go files found in %s, skipping pruning\n", pkgDir)
+			return nil
 		}
 	} else {
 		pkgDir = filepath.Dir(o.Target)

--- a/dev/tools/controllerbuilder/scaffold/apis.go
+++ b/dev/tools/controllerbuilder/scaffold/apis.go
@@ -159,6 +159,15 @@ func (a *APIScaffolder) AddTypeFile(resource options.Resource) error {
 	return scaffoldTypeFile(typeFilePath, cArgs)
 }
 
+func (a *APIScaffolder) AddTypeFileWithFields(resource options.Resource, parentFields, specFields, observedStateFields string) error {
+	typeFilePath := a.PathToTypeFile(resource)
+	cArgs := a.buildAPIArgs(&resource)
+	cArgs.ParentFields = parentFields
+	cArgs.SpecFields = specFields
+	cArgs.ObservedStateFields = observedStateFields
+	return scaffoldTypeFile(typeFilePath, cArgs)
+}
+
 func scaffoldTypeFile(path string, cArgs *apis.APIArgs) error {
 	tmpl, err := template.New(cArgs.Kind).Funcs(funcMap).Parse(apis.TypesTemplate)
 	if err != nil {

--- a/dev/tools/controllerbuilder/template/apis/types.go
+++ b/dev/tools/controllerbuilder/template/apis/types.go
@@ -12,6 +12,10 @@ type APIArgs struct {
 	ProtoMessageName string
 	// ProtoMessageFullName is the fully qualified proto message name, e.g. google.cloud.v1.Foo
 	ProtoMessageFullName string
+
+	ParentFields        string
+	SpecFields          string
+	ObservedStateFields string
 }
 
 const TypesTemplate = `
@@ -44,6 +48,9 @@ var {{ .Kind }}GVK = GroupVersion.WithKind("{{ .Kind }}")
 // +kcc:spec:proto={{ .KindProtoTag }}
 {{- end }}
 type {{ .Kind }}Spec struct {
+{{- if .ParentFields }}
+{{ .ParentFields }}
+{{- else }}
 	// The project that this resource belongs to.
 	ProjectRef *refsv1beta1.ProjectRef ` + "`" + `json:"projectRef"` + "`" + `
 
@@ -52,6 +59,10 @@ type {{ .Kind }}Spec struct {
 
 	// The {{ .Kind }} name. If not given, the metadata.name will be used.
 	ResourceID *string ` + "`" + `json:"resourceID,omitempty"` + "`" + `
+{{- end }}
+{{- if .SpecFields }}
+{{ .SpecFields }}
+{{- end }}
 }
 
 // {{ .Kind }}Status defines the config connector machine state of {{ .Kind }}
@@ -75,6 +86,9 @@ type {{ .Kind }}Status struct {
 // +kcc:observedstate:proto={{ .KindProtoTag }}
 {{- end }}
 type {{ .Kind }}ObservedState struct {
+{{- if .ObservedStateFields }}
+{{ .ObservedStateFields }}
+{{- end }}
 }
 
 // +genclient


### PR DESCRIPTION
## Summary
This draft PR enhances `controllerbuilder` to dramatically improve deterministic generation accuracy and eliminate mechanical boilerplate:

1. **Direct Root Spec & ObservedState Generation:** Dynamically populates `<Kind>Spec` (non-output fields) and `<Kind>ObservedState` (`OUTPUT_ONLY` lifecycle fields) directly from the root protobuf message descriptor during scaffolding, rather than generating an empty stub.
2. **Parent Reference Inference:** Automatically parses `(google.api.resource).pattern` to infer parent references (`ProjectRef`, `FolderRef`, `Location`).
3. **Duplicate Struct Elimination:** Automatically excludes the root proto message struct from `types.generated.go` since it is defined in `<kind>_types.go`.
4. **Prunetypes & Iteratetypes Fixes:** Gracefully handles packages with no generated files in `prunetypes` and cleans up error handling in `iteratetypes`.

Draft PR - do not send for review.