### PR TITLE
fix(orgpolicy): stop OrgPolicyPolicy from calling UpdatePolicy on every reconcile

### DIFF
--- a/pkg/controller/direct/orgpolicy/orgpolicypolicy_controller.go
+++ b/pkg/controller/direct/orgpolicy/orgpolicypolicy_controller.go
@@ -168,7 +168,7 @@ func (a *PolicyAdapter) Update(ctx context.Context, updateOp *directbase.UpdateO
 		return mapCtx.Err()
 	}
 
-	if proto.Equal(a.actual.GetSpec(), desiredPb.GetSpec()) && proto.Equal(a.actual.GetDryRunSpec(), desiredPb.GetDryRunSpec()) {
+	if policySpecEqual(a.actual.GetSpec(), desiredPb.GetSpec()) && policySpecEqual(a.actual.GetDryRunSpec(), desiredPb.GetDryRunSpec()) {
 		log.V(2).Info("Policy is already up to date", "name", a.id)
 		// The resource is already up to date, but we still need to update the status
 		// to reflect the actual state from the backend.
@@ -207,6 +207,16 @@ func (a *PolicyAdapter) Update(ctx context.Context, updateOp *directbase.UpdateO
 	}
 	status.ExternalRef = direct.LazyPtr(a.id.String())
 	return updateOp.UpdateStatus(ctx, status, nil)
+}
+
+func policySpecEqual(actual, desired *orgpolicypb.PolicySpec) bool {
+	if actual == nil || desired == nil {
+		return proto.Equal(actual, desired)
+	}
+	normalized := proto.Clone(actual).(*orgpolicypb.PolicySpec)
+	normalized.Etag = ""
+	normalized.UpdateTime = nil
+	return proto.Equal(normalized, desired)
 }
 
 // Export maps the GCP object to a Config Connector resource `spec`.


### PR DESCRIPTION
### BRIEF Change description

`PolicyAdapter.Update` in `pkg/controller/direct/orgpolicy/orgpolicypolicy_controller.go` decides whether the live policy matches the manifest with `proto.Equal(a.actual.GetSpec(), desiredPb.GetSpec())`. The `PolicySpec` returned by the API carries the output-only fields `etag` and `update_time`; the spec mapped from the KRM object never does (`policy_mappers.go` marks both `// MISSING`). The comparison is therefore always false, the controller calls `UpdatePolicy` on every reconcile, the API mints a new `etag`/`update_time`, and the next reconcile repeats.

This PR compares a copy of the actual spec with `Etag` and `UpdateTime` cleared, for both `spec` and `dryRunSpec`.

Fixes #12755

#### WHY do we need this change?

On a live organization with 11 `OrgPolicyPolicy` objects, the activity audit log shows about 65 `google.cloud.orgpolicy.v2.OrgPolicy.UpdatePolicy` calls per hour from the KCC service account, all with identical request bodies. Only `etag` and `updateTime` change in the responses. This buries real policy changes in audit-log noise and spends API quota for no effect. `ResourceManagerPolicy` objects on the same organization (Terraform-based controller) do not show this.

#### Special notes for your reviewer:

- The mock-backed fixtures cannot observe this bug: each step triggers exactly one reconcile with a real diff, so the golden HTTP logs are unchanged by this PR (`RUN_TESTS=TestAllInSeries/fixtures/orgpolicypolicy ./dev/tasks/run-e2e`: 14/14 pass, no golden changes).
- `proto.Clone` is used so `a.actual` is not mutated; `Export` and `ObservedState` still see the real `etag`/`update_time`.
- Ran: `go build`, `go vet ./pkg/controller/direct/orgpolicy/`, `gofmt -l`.

#### Does this PR add something which needs to be 'release noted'?

```release-note
OrgPolicyPolicy no longer calls UpdatePolicy on every reconcile when the live policy already matches the desired spec. The output-only `etag` and `update_time` fields are now ignored when comparing the live PolicySpec with the desired one.
```

- [ ] Reviewer reviewed release note.
