### PR TITLE
fix(datamigration): filter immutable fields from DatabaseMigrationMigrationJob update mask

### DIFF
--- a/pkg/controller/direct/datamigration/databasemigrationmigrationjob/databasemigrationmigrationjob_controller.go
+++ b/pkg/controller/direct/datamigration/databasemigrationmigrationjob/databasemigrationmigrationjob_controller.go
@@ -177,6 +177,11 @@ func (a *Adapter) Update(ctx context.Context, updateOp *directbase.UpdateOperati
 		return a.updateStatus(ctx, updateOp, a.actual)
 	}
 
+	if len(updateMask.GetPaths()) == 0 {
+		log.V(2).Info("no updatable diff detected for DatabaseMigrationMigrationJob", "name", a.id)
+		return a.updateStatus(ctx, updateOp, a.actual)
+	}
+
 	structuredreporting.ReportDiff(ctx, diffs)
 
 	req := &pb.UpdateMigrationJobRequest{
@@ -263,6 +268,18 @@ func compareMigrationJob(ctx context.Context, actual, desired *pb.MigrationJob) 
 	if err != nil {
 		return nil, nil, err
 	}
+
+	var updatablePaths []string
+	for _, path := range updateMask.GetPaths() {
+		switch path {
+		case "source", "destination", "type", "source_database", "destination_database":
+			continue
+		default:
+			updatablePaths = append(updatablePaths, path)
+		}
+	}
+	updateMask.Paths = updatablePaths
+
 	return diffs, updateMask, nil
 }
 

--- a/pkg/controller/direct/datamigration/databasemigrationmigrationjob/databasemigrationmigrationjob_controller_test.go
+++ b/pkg/controller/direct/datamigration/databasemigrationmigrationjob/databasemigrationmigrationjob_controller_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package databasemigrationmigrationjob
+
+import (
+	"context"
+	"testing"
+
+	pb "cloud.google.com/go/clouddms/apiv1/clouddmspb"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestCompareMigrationJob_ExcludesImmutableFields(t *testing.T) {
+	ctx := context.Background()
+
+	actual := &pb.MigrationJob{
+		Name:                "projects/p1/locations/l1/migrationJobs/mj1",
+		DisplayName:         "Old Display Name",
+		Source:              "projects/p1/locations/l1/connectionProfiles/cp-src",
+		Destination:         "projects/p1/locations/l1/connectionProfiles/cp-dst",
+		Type:                pb.MigrationJob_ONE_TIME,
+		SourceDatabase:      &pb.DatabaseType{Engine: pb.DatabaseEngine_MYSQL},
+		DestinationDatabase: &pb.DatabaseType{Engine: pb.DatabaseEngine_MYSQL},
+	}
+
+	desired := &pb.MigrationJob{
+		Name:                "projects/p1/locations/l1/migrationJobs/mj1",
+		DisplayName:         "New Display Name",
+		Source:              "projects/p1/locations/l1/connectionProfiles/cp-src-new",
+		Destination:         "projects/p1/locations/l1/connectionProfiles/cp-dst-new",
+		Type:                pb.MigrationJob_CONTINUOUS,
+		SourceDatabase:      &pb.DatabaseType{Engine: pb.DatabaseEngine_POSTGRESQL},
+		DestinationDatabase: &pb.DatabaseType{Engine: pb.DatabaseEngine_POSTGRESQL},
+	}
+
+	diffs, updateMask, err := compareMigrationJob(ctx, actual, desired)
+	if err != nil {
+		t.Fatalf("compareMigrationJob failed: %v", err)
+	}
+
+	if !diffs.HasDiff() {
+		t.Errorf("expected diffs, got none")
+	}
+
+	expectedPaths := []string{"display_name"}
+	if diff := cmp.Diff(expectedPaths, updateMask.GetPaths()); diff != "" {
+		t.Errorf("updateMask mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestCompareMigrationJob_NoDiff(t *testing.T) {
+	ctx := context.Background()
+
+	actual := &pb.MigrationJob{
+		Name:        "projects/p1/locations/l1/migrationJobs/mj1",
+		DisplayName: "Same Display Name",
+	}
+
+	desired := &pb.MigrationJob{
+		Name:        "projects/p1/locations/l1/migrationJobs/mj1",
+		DisplayName: "Same Display Name",
+	}
+
+	diffs, updateMask, err := compareMigrationJob(ctx, actual, desired)
+	if err != nil {
+		t.Fatalf("compareMigrationJob failed: %v", err)
+	}
+
+	if diffs.HasDiff() {
+		t.Errorf("expected no diffs, got diffs")
+	}
+
+	if len(updateMask.GetPaths()) != 0 {
+		t.Errorf("expected empty updateMask, got %v", updateMask.GetPaths())
+	}
+}


### PR DESCRIPTION
## Description
Fixes an issue during updates to `DatabaseMigrationMigrationJob`.

When updating a `DatabaseMigrationMigrationJob`, the GCP Cloud DMS API rejects updates if the `updateMask` contains immutable fields such as `source`, `destination`, `type`, `source_database`, or `destination_database`. In live environments, this resulted in:
`rpc error: code = InvalidArgument desc = The path 'destination_database' is not updatable.`

### Changes
1. Filter out immutable paths (`source`, `destination`, `type`, `source_database`, `destination_database`) from `updateMask.Paths` in `compareMigrationJob`.
2. Skip calling `gcpClient.UpdateMigrationJob` when `len(updateMask.GetPaths()) == 0`.
3. Add automated unit tests `TestCompareMigrationJob_ExcludesImmutableFields` and `TestCompareMigrationJob_NoDiff`.

### Verification
- Unit tests pass: `go test -v ./pkg/controller/direct/datamigration/databasemigrationmigrationjob/...`
- Real-world live environment audit in project `gca-gke-2025` (`asia-southeast1`):
  - Model Init: PASS
  - Create: PASS (state transitioned to `NOT_STARTED`)
  - Update: PASS (DisplayName updated and synced via GCP LRO)
  - Find verification: PASS (DisplayName matched updated value)
  - Delete: PASS (LRO waited, resource removed from GCP and K8s)
  - 2 consecutive lifecycle iterations passed (10/10 checks).

Fixes #5677
Resolves b/479282062