### PR TITLE
docs(container): document cpuCfsQuota defaulting behavior in kubeletConfig

### DIFF
--- a/apis/container/v1beta1/containercluster_types.go
+++ b/apis/container/v1beta1/containercluster_types.go
@@ -633,7 +633,7 @@ type KalmConfig struct {
 
 // +kcc:proto=google.container.v1.NodeKubeletConfig
 type KubeletConfig struct {
-	/* Enable CPU CFS quota enforcement for containers that specify CPU limits. */
+	/* Enable CPU CFS quota enforcement for containers that specify CPU limits. Note: If nodeConfig.kubeletConfig is specified, you must explicitly set cpuCfsQuota: true to maintain GKE's default behavior; otherwise, omitting this field defaults to false which disabled CPU quota enforcement. */
 	// +kcc:proto:field=google.container.v1.NodeKubeletConfig.cpu_cfs_quota
 	CPUCfsQuota *bool `json:"cpuCfsQuota,omitempty"`
 

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_containerclusters.container.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_containerclusters.container.cnrm.cloud.google.com.yaml
@@ -1522,8 +1522,11 @@ spec:
                     description: Node kubelet configs.
                     properties:
                       cpuCfsQuota:
-                        description: Enable CPU CFS quota enforcement for containers
-                          that specify CPU limits.
+                        description: 'Enable CPU CFS quota enforcement for containers
+                          that specify CPU limits. Note: If nodeConfig.kubeletConfig
+                          is specified, you must explicitly set cpuCfsQuota: true
+                          to maintain GKE''s default behavior; otherwise, omitting
+                          this field defaults to false which disabled CPU quota enforcement.'
                         type: boolean
                       cpuCfsQuotaPeriod:
                         description: Set the CPU CFS quota period value 'cpu.cfs_period_us'.

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_containernodepools.container.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_containernodepools.container.cnrm.cloud.google.com.yaml
@@ -784,8 +784,11 @@ spec:
                     description: Node kubelet configs.
                     properties:
                       cpuCfsQuota:
-                        description: Enable CPU CFS quota enforcement for containers
-                          that specify CPU limits.
+                        description: 'Enable CPU CFS quota enforcement for containers
+                          that specify CPU limits. Note: If nodeConfig.kubeletConfig
+                          is specified, you must explicitly set cpuCfsQuota: true
+                          to maintain GKE''s default behavior; otherwise, omitting
+                          this field defaults to false which disabled CPU quota enforcement.'
                         type: boolean
                       cpuCfsQuotaPeriod:
                         description: Set the CPU CFS quota period value 'cpu.cfs_period_us'.

--- a/pkg/clients/generated/apis/container/v1beta1/containercluster_types.go
+++ b/pkg/clients/generated/apis/container/v1beta1/containercluster_types.go
@@ -629,7 +629,7 @@ type ClusterKey struct {
 }
 
 type ClusterKubeletConfig struct {
-	/* Enable CPU CFS quota enforcement for containers that specify CPU limits. */
+	/* Enable CPU CFS quota enforcement for containers that specify CPU limits. Note: If nodeConfig.kubeletConfig is specified, you must explicitly set cpuCfsQuota: true to maintain GKE's default behavior; otherwise, omitting this field defaults to false which disabled CPU quota enforcement. */
 	// +optional
 	CpuCfsQuota *bool `json:"cpuCfsQuota,omitempty"`
 

--- a/pkg/clients/generated/apis/container/v1beta1/containernodepool_types.go
+++ b/pkg/clients/generated/apis/container/v1beta1/containernodepool_types.go
@@ -310,7 +310,7 @@ type NodepoolKey struct {
 }
 
 type NodepoolKubeletConfig struct {
-	/* Enable CPU CFS quota enforcement for containers that specify CPU limits. */
+	/* Enable CPU CFS quota enforcement for containers that specify CPU limits. Note: If nodeConfig.kubeletConfig is specified, you must explicitly set cpuCfsQuota: true to maintain GKE's default behavior; otherwise, omitting this field defaults to false which disabled CPU quota enforcement. */
 	// +optional
 	CpuCfsQuota *bool `json:"cpuCfsQuota,omitempty"`
 

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/container/containercluster.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/container/containercluster.md
@@ -3432,7 +3432,7 @@ A duration in seconds with up to nine fractional digits, ending with 's'. Exampl
         </td>
         <td>
             <p><code class="apitype">boolean</code></p>
-            <p>Enable CPU CFS quota enforcement for containers that specify CPU limits.</p>
+            <p>Enable CPU CFS quota enforcement for containers that specify CPU limits. Note: If nodeConfig.kubeletConfig is specified, you must explicitly set cpuCfsQuota: true to maintain GKE's default behavior; otherwise, omitting this field defaults to false which disabled CPU quota enforcement.</p>
         </td>
     </tr>
     <tr>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/container/containernodepool.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/container/containernodepool.md
@@ -1619,7 +1619,7 @@ version: string
         </td>
         <td>
             <p><code class="apitype">boolean</code></p>
-            <p>Enable CPU CFS quota enforcement for containers that specify CPU limits.</p>
+            <p>Enable CPU CFS quota enforcement for containers that specify CPU limits. Note: If nodeConfig.kubeletConfig is specified, you must explicitly set cpuCfsQuota: true to maintain GKE's default behavior; otherwise, omitting this field defaults to false which disabled CPU quota enforcement.</p>
         </td>
     </tr>
     <tr>

--- a/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/container/node_config.go
+++ b/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/container/node_config.go
@@ -504,7 +504,7 @@ func schemaNodeConfig() *schema.Schema {
 							"cpu_cfs_quota": {
 								Type:        schema.TypeBool,
 								Optional:    true,
-								Description: `Enable CPU CFS quota enforcement for containers that specify CPU limits.`,
+								Description: `Enable CPU CFS quota enforcement for containers that specify CPU limits. Note: If nodeConfig.kubeletConfig is specified, you must explicitly set cpuCfsQuota: true to maintain GKE's default behavior; otherwise, omitting this field defaults to false which disabled CPU quota enforcement.`,
 							},
 							"cpu_cfs_quota_period": {
 								Type:        schema.TypeString,


### PR DESCRIPTION
#### Change Description

Clarifies in CRD schemas, Go type definitions, and generated reference documentation (ContainerNodePool and ContainerCluster) that omitting `cpuCfsQuota` when specifying `kubeletConfig` causes Config Connector to default `cpuCfsQuota` to `false` in the GKE API payload, disabling CPU CFS quota enforcement. Explicitly setting `cpuCfsQuota: true` is required to preserve GKE's default behavior.

Fixes b/553981933

#### WHY do we need this change?

To document the behavior that Config Connector defaults `cpuCfsQuota` to false when `kubeletConfig` is configured, so users know to set `cpuCfsQuota: true` to maintain GKE's default CPU CFS quota enforcement.

#### Does this PR add something which needs to be 'release noted'?

```release-note
NONE
```

### Tests you have done

- Regenerated CRDs and reference documentation with `go run ./scripts/generate-google3-docs/resource-reference/main.go --flavor=github`.